### PR TITLE
Per-user PICA shader cache with startup pipeline prewarm (Citra/Azahar model)

### DIFF
--- a/docs/TRIAEVUM_LOCAL_SHADER_CACHE.md
+++ b/docs/TRIAEVUM_LOCAL_SHADER_CACHE.md
@@ -1,0 +1,78 @@
+# Per-user shader cache and startup prewarm
+
+TriAevum generates host shaders from live PICA state, so the shader set cannot be
+enumerated ahead of time. The runtime now removes *repeat* hitches the way
+Citra/Azahar do (`src/video_core/renderer_vulkan/vk_shader_disk_cache.cpp`,
+`vk_pipeline_cache.cpp`): persist what was discovered, and rebuild all of it
+before the game runs. A brand-new install still compiles on first encounter;
+closing that gap needs a first-launch compile of the public inventory, which is
+not implemented.
+
+| Azahar | TriAevum |
+| --- | --- |
+| transferable cache: shader configs + SPIR-V + pipeline configs, per title | `local_pica_shaders.o3ps` (SPIR-V, keyed by shader source identity) and `local_pica_pipelines.json` (complete pipeline state incl. shader identities) under the SDL pref path `oot3d_native_vulkan/shader_cache/` |
+| driver pipeline cache per vendor/device | `pipeline_cache.bin`, validated against vendor/device/UUID (pre-existing) |
+| `InitPLCache` rebuilds every pipeline behind a load callback | `PrewarmNativePicaPipelines` builds every entry matching the active renderer profile; the guest is held and an ImGui "Preparing shaders N / M" overlay is drawn until the batch drains |
+| async `TryBuild(false)` skip-draw fallback | not implemented; a pipeline created on a draw is the hitch being removed, and skipped draws would break rendering parity |
+
+## Runtime behaviour
+
+- Every shader compiled at runtime (a miss in the shipped pack) and every pipeline
+  created at runtime is recorded; both files are rewritten at renderer shutdown.
+  Close the game normally to persist a session. A crash loses that session's new
+  entries (not the existing cache); append-on-discovery is deferred until the
+  I/O cost is measured off the render thread.
+- On the next launch the cache is loaded, then `Fast3dGui` shows the overlay while
+  `GfxRenderingAPIVulkan::StartFrame` creates the pipelines in budgeted slices
+  (`OOT3D_PICA_PIPELINE_PREWARM_BUDGET_MS`, default 50). The native host loop
+  (`oot3d_native_a32_window.cpp`) advances no guest frame while
+  `NativePicaPipelinePrewarmProgress().Blocking` is set, including the frame in
+  which a renderer-profile change enqueues a new batch.
+- Both files carry the descriptor schema; a mismatch with the shipped pack
+  discards the local cache. Stale entries are harmless: unknown shader
+  identities simply never match.
+- `OOT3D_PICA_LOCAL_SHADER_CACHE=0` disables the cache. `--pica-aot-shader-strict`
+  disables it implicitly: strict validation must answer whether the selected pack
+  covers the content, not whether this machine has seen it before.
+- The shipped `.o3ps` pack and an optional `--pica-pipeline-manifest` +
+  `--pica-pipeline-prewarm` pair use the same prewarm queue. The pack is
+  game-derived and is forbidden from public release payloads
+  (`tools/triaevum_release/release_policy.json`), which is why Forge does not pass
+  one; the per-user cache is what every user gets today, for content already seen.
+
+## Extending a shared corpus locally
+
+`scripts/run-linux-title.sh` records inventories with `TRIAEVUM_SHADER_INVENTORY=1`
+and `scripts/extend-pica-corpus.sh` folds them into a candidate pack and manifest
+under `<runtime>/pica-corpus/`. Launch with `TRIAEVUM_PICA_CORPUS=1`
+(+ `TRIAEVUM_PICA_STRICT=1` to validate, `TRIAEVUM_PIPELINE_PREWARM=1` to prewarm).
+
+The manifest schema change is covered by
+`tests/oot3d_pica_pipeline_manifest_tests.cpp`
+(`OutlineOcclusionFlagIsCompatibleWithOlderManifests`). The `tests/` CMake tree
+currently does not build with Linux Clang (it passes the MSVC-only `/WX-` flag to
+any Clang, and `oot3d_effect_graph_tests` lacks a `Vulkan::Vulkan` dependency);
+until that is fixed, build the target's source list directly against system gtest
+and nlohmann/json:
+
+```sh
+cd runtime/three_ds_recomp && clang++ -std=c++20 -Iinclude \
+  tests/oot3d_pica_pipeline_manifest_tests.cpp \
+  src/fast/oot3d/pica_pipeline_manifest.cpp src/fast/oot3d/pica_aot_shader_pack.cpp \
+  -lgtest -lgtest_main -pthread -o /tmp/manifest_tests && /tmp/manifest_tests
+```
+
+## Verification (2026-09-09, Intel Arc Meteor Lake, Mesa)
+
+Fixed-step replays (`--frames 1500 --fixed-delta-seconds 0.016666`) from an empty
+cache directory:
+
+| Run | prewarm batches | runtime shader compiles | runtime pipeline creations |
+| --- | ---: | ---: | ---: |
+| cold | 0 | 18 misses (16 new modules) | 58 |
+| warm 1-3 | 58 pipelines, 15-26 ms each, before the first guest frame | 0 | 0 |
+
+Strict mode with the baseline pack and a populated local cache aborts on the first
+uncovered shader; with the 322-module candidate corpus it passes 66/66.
+The "Preparing shaders" overlay could not be captured: `--screenshot` reads the
+game framebuffer, not the composited swapchain.

--- a/runtime/three_ds_recomp/include/fast/backends/gfx_rendering_api.h
+++ b/runtime/three_ds_recomp/include/fast/backends/gfx_rendering_api.h
@@ -62,6 +62,14 @@ using GfxNativePicaDisplayImageColorSnapshot =
 using GfxNativePicaPresentationStateSnapshot =
     ::Fast::Renderer3ds::PicaPresentationStateSnapshot;
 
+// Startup shader/pipeline precompilation state. While Blocking, the host must
+// hold the guest and show progress instead of advancing the game.
+struct GfxNativePicaPrewarmProgress {
+    uint32_t Completed = 0;
+    uint32_t Total = 0;
+    bool Blocking = false;
+};
+
 struct GfxNativePicaBackendStats {
     bool Available = false;
     bool GeometryCacheEnabled = false;
@@ -204,6 +212,10 @@ class GfxRenderingAPI : public ::Fast::Renderer3ds::PicaRenderBackend {
         return {};
     }
     virtual void SetNativePicaGeometryCacheEnabled(bool) noexcept {
+    }
+    virtual GfxNativePicaPrewarmProgress NativePicaPipelinePrewarmProgress()
+        const noexcept {
+        return {};
     }
     bool SubmitPicaDraw(const GfxNativePicaDrawView&,
                         std::string* error = nullptr) override {

--- a/runtime/three_ds_recomp/include/fast/backends/gfx_vulkan.h
+++ b/runtime/three_ds_recomp/include/fast/backends/gfx_vulkan.h
@@ -144,6 +144,8 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
     bool SetOot3dPicaAlphaTestShaderParameters(bool enabled, uint32_t function,
                                                uint8_t reference) override;
     bool SupportsOot3dPicaTexture2() const override;
+    GfxNativePicaPrewarmProgress NativePicaPipelinePrewarmProgress()
+        const noexcept override;
     bool PublishPicaCompositionSequence(
         const ::Fast::Renderer3ds::PicaCompositionSequenceView& sequence,
         std::string* error = nullptr) override;
@@ -638,11 +640,26 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
         const std::string& source, bool vertexShader,
         const char* sourceName);
     void ConfigureNativePicaAotShaders();
+    void ConfigureLocalPicaShaderCache();
+    void StoreLocalPicaShaderCache();
     void FinishNativePicaAotShaders();
     void PrewarmNativePicaPipelines();
+    void PrewarmNativePicaPipelineEntry(
+        const Oot3d::PicaGraphicsPipelineManifestEntry& entry);
+    std::span<const uint32_t> FindNativePicaAotSpirv(
+        Oot3d::PicaAotShaderStage stage,
+        const Oot3d::PicaAotShaderSourceIdentity& source) const noexcept;
     std::vector<uint32_t> ResolveNativePicaShaderSpirv(
         std::string_view source, Oot3d::PicaAotShaderStage stage,
         bool vertexShader, const char* sourceName);
+    Oot3d::PicaGraphicsPipelineManifestEntry
+    BuildNativePicaPipelineManifestEntry(
+        const GfxNativePicaDrawView& draw,
+        const NativePicaShaderProgram& shader, bool writesReactiveMask,
+        Oot3d::PicaShaderDomain domain,
+        Oot3d::PicaShaderInstrumentationFeature requestedFeatures,
+        Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
+        bool outlineOcclusionOnly) const;
     VkShaderModule CreateShaderModuleFromSpirv(
         std::span<const uint32_t> spirv);
     VkPipeline GetOrCreateNativePicaPipeline(
@@ -765,10 +782,26 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
     Oot3d::PicaEffectiveShaderInventory mPicaEffectiveShaderInventory;
     Oot3d::PicaGraphicsPipelineInventory mPicaPipelineInventory;
     Oot3d::PicaGraphicsPipelineManifest mPicaPipelineManifest;
+    // Per-user disk cache: shaders and pipelines discovered at runtime.
+    Oot3d::PicaAotShaderPack mLocalPicaShaderPack;
+    Oot3d::PicaGraphicsPipelineManifest mLocalPicaPipelineManifest;
+    Oot3d::PicaGraphicsPipelineInventory mLocalPicaPipelineInventory;
+    std::vector<Oot3d::PicaAotShaderBinary> mLocalPicaShaderAdditions;
+    std::set<std::pair<Oot3d::PicaAotShaderStage,
+                       Oot3d::PicaAotShaderSourceIdentity>>
+        mLocalPicaShaderAdditionKeys;
+    uint64_t mLocalPicaPipelinesAdded = 0U;
+    uint32_t mLocalPicaDescriptorSchema = 0U;
+    bool mLocalPicaCacheEnabled = false;
+    std::vector<const Oot3d::PicaGraphicsPipelineManifestEntry*>
+        mPicaPipelinePrewarmQueue;
+    size_t mPicaPipelinePrewarmCursor = 0U;
+    std::chrono::steady_clock::time_point mPicaPipelinePrewarmBatchStart{};
     std::set<uint64_t> mPicaPipelinePrewarmedProfiles;
     std::set<std::pair<Oot3d::PicaAotShaderStage, uint64_t>>
         mPicaAotShaderMissesLogged;
     uint64_t mPicaAotShaderHits = 0;
+    uint64_t mLocalPicaShaderHits = 0;
     uint64_t mPicaAotShaderMisses = 0;
     bool mPicaAotShaderStrict = false;
     bool mPicaAotShaderSummaryLogged = false;

--- a/runtime/three_ds_recomp/include/fast/oot3d/pica_aot_shader_pack.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/pica_aot_shader_pack.h
@@ -64,6 +64,8 @@ class PicaAotShaderPack final {
     [[nodiscard]] bool Loaded() const noexcept;
     [[nodiscard]] uint32_t DescriptorSchemaVersion() const noexcept;
     [[nodiscard]] size_t EntryCount() const noexcept;
+    // Copies every module; for merging into a rewritten pack at shutdown.
+    [[nodiscard]] std::vector<PicaAotShaderBinary> Binaries() const;
     [[nodiscard]] const std::filesystem::path& Path() const noexcept;
 
   private:

--- a/runtime/three_ds_recomp/include/fast/oot3d/pica_pipeline_manifest.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/pica_pipeline_manifest.h
@@ -100,6 +100,8 @@ struct PicaGraphicsPipelineManifestEntry {
     uint8_t AttachmentRequirementsKey = 0U;
     uint8_t SampleCount = 1U;
     bool WritesReactiveMask = false;
+    // Pipeline keyed separately at runtime; absent in older manifests.
+    bool OutlineOcclusionOnly = false;
     ::Oot3d::Renderer::PicaTopology Topology =
         ::Oot3d::Renderer::PicaTopology::TriangleList;
     ::Oot3d::Renderer::NativeCullMode CullMode =

--- a/runtime/three_ds_recomp/src/fast/Fast3dGui.cpp
+++ b/runtime/three_ds_recomp/src/fast/Fast3dGui.cpp
@@ -331,6 +331,34 @@ void Fast3dGui::DrawMenu() {
                 mouse->UpdateMouseCapture();
             }
         }
+        if (const auto* api = window != nullptr
+                                  ? window->GetCurrentRenderingAPI()
+                                  : nullptr;
+            api != nullptr) {
+            const auto prewarm = api->NativePicaPipelinePrewarmProgress();
+            if (prewarm.Blocking) {
+                const ImGuiViewport* viewport = ImGui::GetMainViewport();
+                ImGui::SetNextWindowPos(
+                    {viewport->WorkPos.x + viewport->WorkSize.x * 0.5F,
+                     viewport->WorkPos.y + viewport->WorkSize.y * 0.5F},
+                    ImGuiCond_Always, {0.5F, 0.5F});
+                ImGui::SetNextWindowBgAlpha(0.85F);
+                ImGui::Begin("Preparing shaders", nullptr,
+                             ImGuiWindowFlags_NoDecoration |
+                                 ImGuiWindowFlags_NoInputs |
+                                 ImGuiWindowFlags_AlwaysAutoResize |
+                                 ImGuiWindowFlags_NoSavedSettings);
+                ImGui::Text("Preparing shaders  %u / %u", prewarm.Completed,
+                            prewarm.Total);
+                ImGui::ProgressBar(
+                    prewarm.Total == 0U
+                        ? 0.0F
+                        : static_cast<float>(prewarm.Completed) /
+                              static_cast<float>(prewarm.Total),
+                    {320.0F, 0.0F}, "");
+                ImGui::End();
+            }
+        }
     }
 #endif
 }

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
@@ -45,6 +45,9 @@ constexpr uint32_t kVulkanShaderCacheVersion = 1;
 constexpr uint32_t kVulkanPipelineCacheVersion = 1;
 constexpr uint32_t kSpirvMagic = 0x07230203U;
 constexpr uint64_t kMaximumPipelineCacheBytes = 64ULL * 1024ULL * 1024ULL;
+constexpr const char* kLocalPicaShaderPackName = "local_pica_shaders.o3ps";
+constexpr const char* kLocalPicaPipelineManifestName =
+    "local_pica_pipelines.json";
 
 void* ResolveNriNativeWindow(GfxWindowBackendSDL2* backend) {
 #ifdef _WIN32
@@ -1313,6 +1316,11 @@ void GfxRenderingAPIVulkan::Shutdown() {
         WaitForAllPresents();
         StopPresentWorker();
         vkDeviceWaitIdle(mDevice);
+        // A frame that failed mid-record (strict shader miss) never submits;
+        // ending its pass on a torn-down scope crashes the driver. Freeing the
+        // pool below is valid for a command buffer in the recording state.
+        mNativePicaRenderPassActive = false;
+        mActiveNativePicaRenderTarget = nullptr;
         ShutdownImGuiBackend();
         mSceneSurfaces.Clear();
         mResourceStates.Clear();
@@ -3728,6 +3736,7 @@ void GfxRenderingAPIVulkan::ConfigureNativePicaAotShaders() {
     mPicaPipelinePrewarmedProfiles.clear();
     mPicaAotShaderMissesLogged.clear();
     mPicaAotShaderHits = 0;
+    mLocalPicaShaderHits = 0;
     mPicaAotShaderMisses = 0;
     mPicaAotShaderSummaryLogged = false;
     mPicaPipelinePrewarmSummaryLogged = false;
@@ -3811,9 +3820,132 @@ void GfxRenderingAPIVulkan::ConfigureNativePicaAotShaders() {
             "OOT3D_PICA_PIPELINE_PREWARM requires both a pipeline manifest "
             "and an AOT shader pack");
     }
+    ConfigureLocalPicaShaderCache();
+}
+
+// Per-user disk shader cache, modelled on Citra's: every shader compiled at
+// runtime and every pipeline created at runtime is persisted at shutdown, and
+// the next launch prewarms all of it before the guest runs. SPIR-V and the
+// pipeline descriptors are hardware-independent; the driver's own cache holds
+// the per-GPU binaries.
+void GfxRenderingAPIVulkan::ConfigureLocalPicaShaderCache() {
+    mLocalPicaShaderPack.Clear();
+    mLocalPicaPipelineManifest.Clear();
+    mLocalPicaPipelineInventory.Clear();
+    mLocalPicaShaderAdditions.clear();
+    mLocalPicaShaderAdditionKeys.clear();
+    mLocalPicaPipelinesAdded = 0U;
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
+    const char* disabled = std::getenv("OOT3D_PICA_LOCAL_SHADER_CACHE");
+    // Strict validation answers "does the selected pack cover this content";
+    // the per-user cache would answer it falsely.
+    mLocalPicaCacheEnabled =
+        !mPicaAotShaderStrict &&
+        !(disabled != nullptr && std::string_view(disabled) == "0") &&
+        !VulkanShaderCacheDirectory().empty();
+    if (!mLocalPicaCacheEnabled) {
+        return;
+    }
+    const auto directory = VulkanShaderCacheDirectory();
+    std::string error;
+    if (!mLocalPicaPipelineInventory.Configure(
+            directory / kLocalPicaPipelineManifestName, &error)) {
+        SPDLOG_WARN("Local PICA pipeline cache disabled: {}", error);
+        mLocalPicaCacheEnabled = false;
+        return;
+    }
+    std::error_code ignored;
+    const auto packPath = directory / kLocalPicaShaderPackName;
+    if (std::filesystem::exists(packPath, ignored) &&
+        !mLocalPicaShaderPack.Load(packPath, &error)) {
+        SPDLOG_WARN("Local PICA shader pack ignored: {}", error);
+        mLocalPicaShaderPack.Clear();
+    }
+    if (mLocalPicaShaderPack.Loaded() && mPicaAotShaderPack.Loaded() &&
+        mLocalPicaShaderPack.DescriptorSchemaVersion() !=
+            mPicaAotShaderPack.DescriptorSchemaVersion()) {
+        SPDLOG_WARN("Local PICA shader pack ignored: descriptor schema {} "
+                    "differs from shipped pack schema {}",
+                    mLocalPicaShaderPack.DescriptorSchemaVersion(),
+                    mPicaAotShaderPack.DescriptorSchemaVersion());
+        mLocalPicaShaderPack.Clear();
+    }
+    const auto manifestPath = mLocalPicaPipelineInventory.Path();
+    if (std::filesystem::exists(manifestPath, ignored) &&
+        !mLocalPicaPipelineManifest.Load(manifestPath, &error)) {
+        SPDLOG_WARN("Local PICA pipeline manifest ignored: {}", error);
+        mLocalPicaPipelineManifest.Clear();
+    }
+    if (mLocalPicaPipelineManifest.Loaded() &&
+        mLocalPicaPipelineManifest.DescriptorSchemaVersion() !=
+            (mPicaAotShaderPack.Loaded()
+                 ? mPicaAotShaderPack.DescriptorSchemaVersion()
+                 : mLocalPicaShaderPack.DescriptorSchemaVersion())) {
+        SPDLOG_WARN("Local PICA pipeline manifest ignored: descriptor "
+                    "schema mismatch");
+        mLocalPicaPipelineManifest.Clear();
+    }
+    // Seed the inventory so the rewritten manifest is the union.
+    for (const auto& entry : mLocalPicaPipelineManifest.Entries()) {
+        mLocalPicaPipelineInventory.Observe(entry, 0U, 0U);
+    }
+    std::fprintf(stderr,
+                 "OOT3D_PICA_LOCAL_SHADER_CACHE modules=%zu pipelines=%zu "
+                 "path=%s\n",
+                 mLocalPicaShaderPack.EntryCount(),
+                 mLocalPicaPipelineManifest.Entries().size(),
+                 directory.string().c_str());
+}
+
+void GfxRenderingAPIVulkan::StoreLocalPicaShaderCache() {
+    if (!mLocalPicaCacheEnabled) {
+        return;
+    }
+    std::string error;
+    std::fprintf(stderr,
+                 "OOT3D_PICA_LOCAL_SHADER_CACHE session added_modules=%zu "
+                 "added_pipelines=%llu\n",
+                 mLocalPicaShaderAdditions.size(),
+                 static_cast<unsigned long long>(mLocalPicaPipelinesAdded));
+    if (!mLocalPicaShaderAdditions.empty()) {
+        auto binaries = mLocalPicaShaderPack.Binaries();
+        binaries.insert(binaries.end(), mLocalPicaShaderAdditions.begin(),
+                        mLocalPicaShaderAdditions.end());
+        const uint32_t schema = mPicaAotShaderPack.Loaded()
+            ? mPicaAotShaderPack.DescriptorSchemaVersion()
+            : mLocalPicaShaderPack.Loaded()
+                  ? mLocalPicaShaderPack.DescriptorSchemaVersion()
+                  : mLocalPicaDescriptorSchema;
+        const auto path =
+            VulkanShaderCacheDirectory() / kLocalPicaShaderPackName;
+        if (schema == 0U) {
+            SPDLOG_WARN("Local PICA shader pack not written: no descriptor "
+                        "schema observed");
+        } else if (!Oot3d::WritePicaAotShaderPack(path, schema, binaries,
+                                                  &error)) {
+            SPDLOG_WARN("Local PICA shader pack not written: {}", error);
+        } else {
+            std::fprintf(stderr,
+                         "OOT3D_PICA_LOCAL_SHADER_CACHE wrote modules=%zu\n",
+                         binaries.size());
+            mLocalPicaShaderAdditions.clear();
+        }
+    }
+    if (mLocalPicaPipelinesAdded != 0U) {
+        if (!mLocalPicaPipelineInventory.Finish(&error)) {
+            SPDLOG_WARN("Local PICA pipeline manifest not written: {}", error);
+        } else {
+            std::fprintf(stderr,
+                         "OOT3D_PICA_LOCAL_SHADER_CACHE wrote pipelines=%zu\n",
+                         mLocalPicaPipelineInventory.EntryCount());
+            mLocalPicaPipelinesAdded = 0U;
+        }
+    }
 }
 
 void GfxRenderingAPIVulkan::FinishNativePicaAotShaders() {
+    StoreLocalPicaShaderCache();
     if (mPicaEffectiveShaderInventory.Enabled()) {
         std::string error;
         if (!mPicaEffectiveShaderInventory.Finish(&error)) {
@@ -3866,13 +3998,16 @@ void GfxRenderingAPIVulkan::FinishNativePicaAotShaders() {
     }
     if (!mPicaAotShaderSummaryLogged &&
         (mPicaAotShaderPack.Loaded() || mPicaAotShaderHits != 0U ||
-         mPicaAotShaderMisses != 0U)) {
-        SPDLOG_INFO("Native PICA AOT shader resolution: {} hits, {} misses",
-                    mPicaAotShaderHits, mPicaAotShaderMisses);
+         mLocalPicaShaderHits != 0U || mPicaAotShaderMisses != 0U)) {
+        SPDLOG_INFO("Native PICA AOT shader resolution: {} shipped hits, "
+                    "{} local hits, {} misses",
+                    mPicaAotShaderHits, mLocalPicaShaderHits,
+                    mPicaAotShaderMisses);
         std::fprintf(stderr,
-                     "OOT3D_PICA_AOT_SHADER_RESOLUTION hits=%llu misses=%llu "
-                     "strict=%u entries=%zu\n",
+                     "OOT3D_PICA_AOT_SHADER_RESOLUTION hits=%llu "
+                     "local_hits=%llu misses=%llu strict=%u entries=%zu\n",
                      static_cast<unsigned long long>(mPicaAotShaderHits),
+                     static_cast<unsigned long long>(mLocalPicaShaderHits),
                      static_cast<unsigned long long>(mPicaAotShaderMisses),
                      mPicaAotShaderStrict ? 1U : 0U,
                      mPicaAotShaderPack.EntryCount());
@@ -3884,18 +4019,28 @@ std::vector<uint32_t>
 GfxRenderingAPIVulkan::ResolveNativePicaShaderSpirv(
     std::string_view source, Oot3d::PicaAotShaderStage stage,
     bool vertexShader, const char* sourceName) {
-    if (!mPicaAotShaderPack.Loaded()) {
+    const bool anyPack =
+        mPicaAotShaderPack.Loaded() || mLocalPicaShaderPack.Loaded();
+    if (!anyPack && !mLocalPicaCacheEnabled) {
         return CompileShaderSpirv(std::string(source), vertexShader,
                                   sourceName);
     }
-    const auto binary = mPicaAotShaderPack.Find(stage, source);
+    const auto identity = Oot3d::IdentifyPicaAotShaderSource(source);
+    // Strict validation must be satisfied only by the explicitly selected pack.
+    const auto binary = mPicaAotShaderStrict
+        ? mPicaAotShaderPack.Find(stage, identity)
+        : FindNativePicaAotSpirv(stage, identity);
     if (!binary.empty()) {
-        ++mPicaAotShaderHits;
+        // "hits" measures shipped-pack coverage; local-cache hits are separate.
+        if (!mPicaAotShaderPack.Find(stage, identity).empty()) {
+            ++mPicaAotShaderHits;
+        } else {
+            ++mLocalPicaShaderHits;
+        }
         return {binary.begin(), binary.end()};
     }
 
     ++mPicaAotShaderMisses;
-    const auto identity = Oot3d::IdentifyPicaAotShaderSource(source);
     if (mPicaAotShaderMissesLogged.insert({stage, identity.Id}).second) {
         SPDLOG_WARN(
             "Native PICA AOT shader miss: stage={}, source={}, name={}",
@@ -3908,8 +4053,13 @@ GfxRenderingAPIVulkan::ResolveNativePicaShaderSpirv(
             std::string(Oot3d::PicaAotShaderStageName(stage)) +
             " module for " + Oot3d::FormatPicaAotShaderId(identity.Id));
     }
-    return CompileShaderSpirv(std::string(source), vertexShader,
-                              sourceName);
+    auto spirv = CompileShaderSpirv(std::string(source), vertexShader,
+                                    sourceName);
+    if (mLocalPicaCacheEnabled &&
+        mLocalPicaShaderAdditionKeys.insert({stage, identity}).second) {
+        mLocalPicaShaderAdditions.push_back({stage, identity, spirv});
+    }
+    return spirv;
 }
 
 VkShaderModule GfxRenderingAPIVulkan::CreateShaderModuleFromSpirv(
@@ -4841,6 +4991,8 @@ void GfxRenderingAPIVulkan::DestroyGraphicsPipelines() {
     }
     mNativePicaPipelines.clear();
     mPicaPipelinePrewarmedProfiles.clear();
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
     if (mNativePicaScanoutPipeline != VK_NULL_HANDLE) {
         vkDestroyPipeline(mDevice, mNativePicaScanoutPipeline, nullptr);
         mNativePicaScanoutPipeline = VK_NULL_HANDLE;

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan_pica.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan_pica.cpp
@@ -977,6 +977,8 @@ void GfxRenderingAPIVulkan::ApplyNativePicaSampleCount(VkSampleCountFlagBits sam
     }
     mNativePicaPipelines.clear();
     mPicaPipelinePrewarmedProfiles.clear();
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
     if (mNativePicaRenderPass != VK_NULL_HANDLE) {
         vkDestroyRenderPass(mDevice, mNativePicaRenderPass, nullptr);
         mNativePicaRenderPass = VK_NULL_HANDLE;
@@ -3269,6 +3271,78 @@ void GfxRenderingAPIVulkan::CreateNativePicaTextureImage(
     RecreateSampler(texture);
 }
 
+Oot3d::PicaGraphicsPipelineManifestEntry
+GfxRenderingAPIVulkan::BuildNativePicaPipelineManifestEntry(
+    const GfxNativePicaDrawView& draw,
+    const NativePicaShaderProgram& shader, bool writesReactiveMask,
+    Oot3d::PicaShaderDomain domain,
+    Oot3d::PicaShaderInstrumentationFeature requestedFeatures,
+    Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
+    bool outlineOcclusionOnly) const {
+    Oot3d::PicaGraphicsPipelineManifestEntry entry;
+    entry.DescriptorSchemaVersion =
+        draw.CanonicalDescriptorSchemaVersion;
+    entry.Domain = domain == Oot3d::PicaShaderDomain::Canonical
+        ? Oot3d::PicaGraphicsPipelineDomain::Canonical
+        : Oot3d::PicaGraphicsPipelineDomain::Instrumented;
+    entry.VertexShaderKey = draw.VertexShaderKey;
+    entry.FragmentShaderKey = draw.FragmentShaderKey;
+    entry.VertexSource = shader.VertexSource;
+    entry.FragmentSource = shader.FragmentSource;
+    entry.NriFragmentSource = shader.NriFragmentSource;
+    entry.NriFragmentAvailable = shader.NriDescriptorContract;
+    entry.RequestedFeatures = requestedFeatures;
+    entry.AppliedFeatures = appliedFeatures;
+    entry.AttachmentRequirementsKey =
+        mFramePicaAttachmentRequirements.Key();
+    entry.SampleCount =
+        static_cast<uint8_t>(mNativePicaSampleCount);
+    entry.WritesReactiveMask = writesReactiveMask;
+    entry.OutlineOcclusionOnly = outlineOcclusionOnly;
+    entry.Topology = draw.Topology;
+    entry.CullMode = draw.CullMode;
+    entry.FramebufferFlipped = draw.FramebufferFlipped;
+    entry.VertexBindings.reserve(draw.VertexBindings.size());
+    for (const auto& binding : draw.VertexBindings) {
+        entry.VertexBindings.push_back({
+            binding.Binding, binding.ByteStride, binding.PerInstance});
+    }
+    entry.VertexAttributes.reserve(draw.VertexAttributes.size());
+    for (const auto& attribute : draw.VertexAttributes) {
+        entry.VertexAttributes.push_back({
+            attribute.Location, attribute.Binding, attribute.Format,
+            attribute.ComponentCount, attribute.ByteOffset});
+    }
+    entry.ColorWriteMask = draw.ColorWriteMask;
+    entry.FragmentOperationMode = draw.FragmentOperationMode;
+    entry.LogicOperation = draw.LogicOperation;
+    entry.Blend = {
+        draw.Blend.Enabled,
+        draw.Blend.EquationRgb,
+        draw.Blend.EquationAlpha,
+        draw.Blend.SourceRgb,
+        draw.Blend.DestRgb,
+        draw.Blend.SourceAlpha,
+        draw.Blend.DestAlpha,
+    };
+    entry.AlphaTestEnabled = draw.AlphaTestEnabled;
+    entry.DepthTestEnabled = draw.DepthTestEnabled;
+    entry.DepthWriteEnabled = draw.DepthWriteEnabled;
+    entry.DepthCompare = draw.DepthCompare;
+    entry.Stencil = {
+        draw.Stencil.Enabled,
+        draw.Stencil.Compare,
+        draw.Stencil.Reference,
+        draw.Stencil.CompareMask,
+        draw.Stencil.WriteMask,
+        draw.Stencil.Fail,
+        draw.Stencil.DepthFail,
+        draw.Stencil.Pass,
+    };
+    entry.ShaderOutputs = shader.FragmentOutputs;
+    return entry;
+}
+
 VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
     const GfxNativePicaDrawView& draw,
     const NativePicaShaderProgram& shader, bool writesReactiveMask,
@@ -3277,69 +3351,11 @@ VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
     Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
     bool recordInventory, bool outlineOcclusionOnly) {
     if (recordInventory && mPicaPipelineInventory.Enabled()) {
-        Oot3d::PicaGraphicsPipelineManifestEntry entry;
-        entry.DescriptorSchemaVersion =
-            draw.CanonicalDescriptorSchemaVersion;
-        entry.Domain = domain == Oot3d::PicaShaderDomain::Canonical
-            ? Oot3d::PicaGraphicsPipelineDomain::Canonical
-            : Oot3d::PicaGraphicsPipelineDomain::Instrumented;
-        entry.VertexShaderKey = draw.VertexShaderKey;
-        entry.FragmentShaderKey = draw.FragmentShaderKey;
-        entry.VertexSource = shader.VertexSource;
-        entry.FragmentSource = shader.FragmentSource;
-        entry.NriFragmentSource = shader.NriFragmentSource;
-        entry.NriFragmentAvailable = shader.NriDescriptorContract;
-        entry.RequestedFeatures = requestedFeatures;
-        entry.AppliedFeatures = appliedFeatures;
-        entry.AttachmentRequirementsKey =
-            mFramePicaAttachmentRequirements.Key();
-        entry.SampleCount =
-            static_cast<uint8_t>(mNativePicaSampleCount);
-        entry.WritesReactiveMask = writesReactiveMask;
-        entry.Topology = draw.Topology;
-        entry.CullMode = draw.CullMode;
-        entry.FramebufferFlipped = draw.FramebufferFlipped;
-        entry.VertexBindings.reserve(draw.VertexBindings.size());
-        for (const auto& binding : draw.VertexBindings) {
-            entry.VertexBindings.push_back({
-                binding.Binding, binding.ByteStride, binding.PerInstance});
-        }
-        entry.VertexAttributes.reserve(draw.VertexAttributes.size());
-        for (const auto& attribute : draw.VertexAttributes) {
-            entry.VertexAttributes.push_back({
-                attribute.Location, attribute.Binding, attribute.Format,
-                attribute.ComponentCount, attribute.ByteOffset});
-        }
-        entry.ColorWriteMask = draw.ColorWriteMask;
-        entry.FragmentOperationMode = draw.FragmentOperationMode;
-        entry.LogicOperation = draw.LogicOperation;
-        entry.Blend = {
-            draw.Blend.Enabled,
-            draw.Blend.EquationRgb,
-            draw.Blend.EquationAlpha,
-            draw.Blend.SourceRgb,
-            draw.Blend.DestRgb,
-            draw.Blend.SourceAlpha,
-            draw.Blend.DestAlpha,
-        };
-        entry.AlphaTestEnabled = draw.AlphaTestEnabled;
-        entry.DepthTestEnabled = draw.DepthTestEnabled;
-        entry.DepthWriteEnabled = draw.DepthWriteEnabled;
-        entry.DepthCompare = draw.DepthCompare;
-        entry.Stencil = {
-            draw.Stencil.Enabled,
-            draw.Stencil.Compare,
-            draw.Stencil.Reference,
-            draw.Stencil.CompareMask,
-            draw.Stencil.WriteMask,
-            draw.Stencil.Fail,
-            draw.Stencil.DepthFail,
-            draw.Stencil.Pass,
-        };
-        entry.ShaderOutputs = shader.FragmentOutputs;
         mPicaPipelineInventory.Observe(
-            std::move(entry), draw.CanonicalPipelineId,
-            mFrameGraphicsSettingsRevision);
+            BuildNativePicaPipelineManifestEntry(
+                draw, shader, writesReactiveMask, domain,
+                requestedFeatures, appliedFeatures, outlineOcclusionOnly),
+            draw.CanonicalPipelineId, mFrameGraphicsSettingsRevision);
     }
     std::vector<uint8_t> key;
     AppendKey(key, static_cast<uint8_t>(outlineOcclusionOnly));
@@ -3707,15 +3723,46 @@ VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
         }
     }
     mNativePicaPipelines.emplace(std::move(key), pipeline);
+    // Only newly created pipelines enter the per-user cache: the next launch
+    // prewarms them before the guest runs.
+    if (recordInventory && mLocalPicaPipelineInventory.Enabled()) {
+        if (mLocalPicaDescriptorSchema == 0U) {
+            mLocalPicaDescriptorSchema = draw.CanonicalDescriptorSchemaVersion;
+        }
+        mLocalPicaPipelineInventory.Observe(
+            BuildNativePicaPipelineManifestEntry(
+                draw, shader, writesReactiveMask, domain,
+                requestedFeatures, appliedFeatures, outlineOcclusionOnly),
+            draw.CanonicalPipelineId, mFrameGraphicsSettingsRevision);
+        ++mLocalPicaPipelinesAdded;
+    }
     return pipeline;
 }
 
+std::span<const uint32_t> GfxRenderingAPIVulkan::FindNativePicaAotSpirv(
+    Oot3d::PicaAotShaderStage stage,
+    const Oot3d::PicaAotShaderSourceIdentity& source) const noexcept {
+    const auto shipped = mPicaAotShaderPack.Find(stage, source);
+    return shipped.empty() ? mLocalPicaShaderPack.Find(stage, source)
+                           : shipped;
+}
+
+GfxNativePicaPrewarmProgress
+GfxRenderingAPIVulkan::NativePicaPipelinePrewarmProgress() const noexcept {
+    // Until StartFrame has evaluated the current profile no queue exists;
+    // hold the guest so its draws cannot race the batch. Every batch holds:
+    // a pipeline created on a draw is exactly the hitch this removes.
+    return {static_cast<uint32_t>(mPicaPipelinePrewarmCursor),
+            static_cast<uint32_t>(mPicaPipelinePrewarmQueue.size()),
+            mPicaPipelinePrewarmedProfiles.empty() ||
+                mPicaPipelinePrewarmCursor < mPicaPipelinePrewarmQueue.size()};
+}
+
 void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
-    if (!mPicaPipelinePrewarmEnabled ||
-        !mPicaPipelineManifest.Loaded() ||
-        !mPicaAotShaderPack.Loaded()) {
-        return;
-    }
+    const bool shipped = mPicaPipelinePrewarmEnabled &&
+                         mPicaPipelineManifest.Loaded() &&
+                         mPicaAotShaderPack.Loaded();
+    const bool local = mLocalPicaPipelineManifest.Loaded();
     const uint8_t sampleCount =
         static_cast<uint8_t>(mNativePicaSampleCount);
     const auto activeFeatures = Oot3d::ResolvePicaShaderProfileFeatures(
@@ -3728,22 +3775,72 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
         (static_cast<uint64_t>(sampleCount) << 8U) |
         (static_cast<uint64_t>(activeFeatures) << 16U) |
         (mNativeFidelityProfile ? 1ULL << 48U : 0U);
-    if (!mPicaPipelinePrewarmedProfiles.insert(profile).second) {
+    if (mPicaPipelinePrewarmedProfiles.insert(profile).second &&
+        (shipped || local)) {
+        const uint32_t schema = mPicaAotShaderPack.Loaded()
+            ? mPicaAotShaderPack.DescriptorSchemaVersion()
+            : mLocalPicaShaderPack.DescriptorSchemaVersion();
+        const auto enqueue = [&](const Oot3d::PicaGraphicsPipelineManifest&
+                                     manifest) {
+            for (const auto& entry : manifest.Entries()) {
+                if (entry.AttachmentRequirementsKey ==
+                        mFramePicaAttachmentRequirements.Key() &&
+                    entry.SampleCount == sampleCount &&
+                    entry.DescriptorSchemaVersion == schema &&
+                    entry.MatchesPrewarmProfile(activeFeatures,
+                                                mNativeFidelityProfile)) {
+                    mPicaPipelinePrewarmQueue.push_back(&entry);
+                }
+            }
+        };
+        // Manifest entry storage is stable until Clear(); pointers are safe.
+        if (shipped) enqueue(mPicaPipelineManifest);
+        if (local) enqueue(mLocalPicaPipelineManifest);
+        if (mPicaPipelinePrewarmCursor == 0U) {
+            mPicaPipelinePrewarmBatchStart = std::chrono::steady_clock::now();
+        }
+    }
+    if (mPicaPipelinePrewarmCursor >= mPicaPipelinePrewarmQueue.size()) {
         return;
     }
+    // The guest is held meanwhile; the budget only bounds overlay latency.
+    static const uint32_t budgetMs = [] {
+        const char* value =
+            std::getenv("OOT3D_PICA_PIPELINE_PREWARM_BUDGET_MS");
+        return value != nullptr ? static_cast<uint32_t>(std::atoi(value))
+                                : 50U;
+    }();
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(budgetMs);
+    while (mPicaPipelinePrewarmCursor < mPicaPipelinePrewarmQueue.size() &&
+           std::chrono::steady_clock::now() < deadline) {
+        PrewarmNativePicaPipelineEntry(
+            *mPicaPipelinePrewarmQueue[mPicaPipelinePrewarmCursor++]);
+    }
+    if (mPicaPipelinePrewarmCursor >= mPicaPipelinePrewarmQueue.size()) {
+        std::fprintf(
+            stderr,
+            "OOT3D_PICA_PIPELINE_PREWARM_BATCH pipelines=%zu ms=%lld "
+            "created=%llu reused=%llu skipped=%llu\n",
+            mPicaPipelinePrewarmQueue.size(),
+            static_cast<long long>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() -
+                    mPicaPipelinePrewarmBatchStart)
+                    .count()),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmCreated),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmReused),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmSkipped));
+        mPicaPipelinePrewarmQueue.clear();
+        mPicaPipelinePrewarmCursor = 0U;
+    }
+}
 
+void GfxRenderingAPIVulkan::PrewarmNativePicaPipelineEntry(
+    const Oot3d::PicaGraphicsPipelineManifestEntry& entry) {
     const std::array<uint8_t, 1> dummyVertexBytes{};
-    for (const auto& entry : mPicaPipelineManifest.Entries()) {
-        if (entry.AttachmentRequirementsKey !=
-                mFramePicaAttachmentRequirements.Key() ||
-            entry.SampleCount != sampleCount ||
-            entry.DescriptorSchemaVersion !=
-                mPicaAotShaderPack.DescriptorSchemaVersion() ||
-            !entry.MatchesPrewarmProfile(
-                activeFeatures, mNativeFidelityProfile)) {
-            continue;
-        }
-
+    {
+        // Profile, sample count and schema were matched when enqueued.
         auto& shaderCache =
             entry.Domain == Oot3d::PicaGraphicsPipelineDomain::Canonical
                 ? mCanonicalNativePicaShaders
@@ -3753,7 +3850,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
         if (mNriPicaPipelineBridge.Available() &&
             !entry.NriFragmentAvailable) {
             ++mPicaPipelinePrewarmSkipped;
-            continue;
+            return;
         }
         auto shaderIt = shaderCache.find(shaderKey);
         if (shaderIt != shaderCache.end() &&
@@ -3767,27 +3864,27 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                   entry.NriFragmentSource) ||
              shaderIt->second.FragmentOutputs != entry.ShaderOutputs)) {
             ++mPicaPipelinePrewarmSkipped;
-            continue;
+            return;
         }
         if (shaderIt == shaderCache.end()) {
-            const auto vertexSpirv = mPicaAotShaderPack.Find(
+            const auto vertexSpirv = FindNativePicaAotSpirv(
                 Oot3d::PicaAotShaderStage::Vertex, entry.VertexSource);
-            const auto fragmentSpirv = mPicaAotShaderPack.Find(
+            const auto fragmentSpirv = FindNativePicaAotSpirv(
                 Oot3d::PicaAotShaderStage::Fragment,
                 entry.FragmentSource);
             if (vertexSpirv.empty() || fragmentSpirv.empty()) {
                 ++mPicaPipelinePrewarmSkipped;
-                continue;
+                return;
             }
             std::span<const uint32_t> nriFragmentSpirv;
             if (entry.NriFragmentAvailable &&
                 mNriPicaPipelineBridge.Available()) {
-                nriFragmentSpirv = mPicaAotShaderPack.Find(
+                nriFragmentSpirv = FindNativePicaAotSpirv(
                     Oot3d::PicaAotShaderStage::NriFragment,
                     entry.NriFragmentSource);
                 if (nriFragmentSpirv.empty()) {
                     ++mPicaPipelinePrewarmSkipped;
-                    continue;
+                    return;
                 }
             }
 
@@ -3823,7 +3920,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                 SPDLOG_WARN(
                     "Native PICA pipeline prewarm shader creation failed: {}",
                     exception.what());
-                continue;
+                return;
             }
         }
 
@@ -3887,7 +3984,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                     ? Oot3d::PicaShaderDomain::Canonical
                     : Oot3d::PicaShaderDomain::Instrumented,
                 entry.RequestedFeatures, entry.AppliedFeatures,
-                false);
+                false, entry.OutlineOcclusionOnly);
             if (mNativePicaPipelines.size() == pipelineCount) {
                 ++mPicaPipelinePrewarmReused;
             } else {
@@ -5418,7 +5515,7 @@ bool GfxRenderingAPIVulkan::SubmitPicaDraw(
             ? GetOrCreateNativePicaPipeline(
                 effectiveDraw, shaderIt->second, shaderVariant.Reactive,
                 shaderVariant.Domain, shaderVariant.RequestedFeatures, shaderVariant.AppliedFeatures,
-                false, true)
+                true, true)
             : VK_NULL_HANDLE;
         // Coverage runs before the native draw: stencil must still have its
         // original value if that draw modifies it. The auxiliary pass is read-only.

--- a/runtime/three_ds_recomp/src/fast/oot3d/pica_aot_shader_pack.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/pica_aot_shader_pack.cpp
@@ -386,6 +386,19 @@ size_t PicaAotShaderPack::EntryCount() const noexcept {
     return mEntries.size();
 }
 
+std::vector<PicaAotShaderBinary> PicaAotShaderPack::Binaries() const {
+    std::vector<PicaAotShaderBinary> result;
+    result.reserve(mEntries.size());
+    for (const auto& [key, range] : mEntries) {
+        const auto spirv = Find(key.Stage, key.Source);
+        if (!spirv.empty()) {
+            result.push_back({key.Stage, key.Source,
+                              {spirv.begin(), spirv.end()}});
+        }
+    }
+    return result;
+}
+
 const std::filesystem::path& PicaAotShaderPack::Path() const noexcept {
     return mPath;
 }

--- a/runtime/three_ds_recomp/src/fast/oot3d/pica_pipeline_manifest.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/pica_pipeline_manifest.cpp
@@ -206,6 +206,7 @@ nlohmann::json EntryJson(
         {"attachment_requirements_key", entry.AttachmentRequirementsKey},
         {"sample_count", entry.SampleCount},
         {"writes_reactive_mask", entry.WritesReactiveMask},
+        {"outline_occlusion_only", entry.OutlineOcclusionOnly},
         {"topology", static_cast<uint8_t>(entry.Topology)},
         {"cull_mode", static_cast<uint8_t>(entry.CullMode)},
         {"framebuffer_flipped", entry.FramebufferFlipped},
@@ -329,6 +330,9 @@ bool ReadEntry(const nlohmann::json& value,
         !ReadUnsigned(value, "sample_count", entry.SampleCount) ||
         !ReadBool(value, "writes_reactive_mask",
                   entry.WritesReactiveMask) ||
+        (value.contains("outline_occlusion_only") &&
+         !ReadBool(value, "outline_occlusion_only",
+                   entry.OutlineOcclusionOnly)) ||
         !value.contains("topology") ||
         !ReadEnum(value["topology"],
                   ::Oot3d::Renderer::PicaTopology::GeometryShader,
@@ -649,6 +653,10 @@ uint64_t PicaGraphicsPipelineManifestEntry::StructuralId() const noexcept {
     HashValue(hash, AttachmentRequirementsKey);
     HashValue(hash, SampleCount);
     HashValue(hash, WritesReactiveMask);
+    // Only hashed when set so ids of pre-existing entries stay valid.
+    if (OutlineOcclusionOnly) {
+        HashValue(hash, OutlineOcclusionOnly);
+    }
     HashValue(hash, Topology);
     HashValue(hash, CullMode);
     HashValue(hash, FramebufferFlipped);
@@ -716,6 +724,7 @@ bool PicaGraphicsPipelineManifestEntry::StructurallyEquivalent(
            AttachmentRequirementsKey == other.AttachmentRequirementsKey &&
            SampleCount == other.SampleCount &&
            WritesReactiveMask == other.WritesReactiveMask &&
+           OutlineOcclusionOnly == other.OutlineOcclusionOnly &&
            Topology == other.Topology && CullMode == other.CullMode &&
            FramebufferFlipped == other.FramebufferFlipped &&
            VertexBindings == other.VertexBindings &&

--- a/runtime/three_ds_recomp/tests/oot3d_pica_pipeline_manifest_tests.cpp
+++ b/runtime/three_ds_recomp/tests/oot3d_pica_pipeline_manifest_tests.cpp
@@ -2,8 +2,12 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
 
 namespace Fast::Oot3d {
 namespace {
@@ -106,6 +110,51 @@ TEST(PicaPipelineManifest, RoundTripsTypedPipelineState) {
     EXPECT_EQ(loaded.ObservationCount, 8U);
     EXPECT_EQ(loaded.CanonicalPipelineIds, entry.CanonicalPipelineIds);
     EXPECT_EQ(loaded.SettingsRevisions, entry.SettingsRevisions);
+
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+}
+
+TEST(PicaPipelineManifest, OutlineOcclusionFlagIsCompatibleWithOlderManifests) {
+    const auto path = TemporaryPath("oot3d_pica_pipeline_outline");
+    auto plain = MakeEntry();
+    auto outline = MakeEntry();
+    outline.OutlineOcclusionOnly = true;
+    EXPECT_NE(plain.StructuralId(), outline.StructuralId());
+    EXPECT_FALSE(plain.StructurallyEquivalent(outline));
+
+    const std::array entries{plain, outline};
+    std::string error;
+    ASSERT_TRUE(WritePicaGraphicsPipelineManifest(
+        path, plain.DescriptorSchemaVersion, entries, &error)) << error;
+
+    // Manifests written before the flag existed carry neither the key nor its
+    // hash contribution; drop every "false" line and the stored ids must still
+    // validate, while the "true" entry keeps its flag and distinct id.
+    std::ifstream input(path);
+    std::stringstream kept;
+    size_t trueLines = 0U;
+    for (std::string line; std::getline(input, line);) {
+        if (line.find("\"outline_occlusion_only\": false") != std::string::npos) {
+            continue;
+        }
+        trueLines += line.find("\"outline_occlusion_only\": true") != std::string::npos;
+        kept << line << '\n';
+    }
+    input.close();
+    ASSERT_EQ(trueLines, 1U);
+    std::ofstream(path, std::ios::trunc) << kept.str();
+
+    PicaGraphicsPipelineManifest manifest;
+    ASSERT_TRUE(manifest.Load(path, &error)) << error;
+    ASSERT_EQ(manifest.Entries().size(), 2U);
+    size_t outlineEntries = 0U;
+    for (const auto& loaded : manifest.Entries()) {
+        outlineEntries += loaded.OutlineOcclusionOnly ? 1U : 0U;
+        EXPECT_TRUE(loaded.StructurallyEquivalent(
+            loaded.OutlineOcclusionOnly ? outline : plain));
+    }
+    EXPECT_EQ(outlineEntries, 1U);
 
     std::error_code ignored;
     std::filesystem::remove(path, ignored);

--- a/scripts/extend-pica-corpus.sh
+++ b/scripts/extend-pica-corpus.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fold a recorded play session (run-linux-title.sh with TRIAEVUM_SHADER_INVENTORY=1,
+# window closed normally) into a candidate AOT shader pack and prewarm manifest
+# under RUNTIME_BUILD/pica-corpus. The checked-in baseline is read, never written.
+# Cumulative: the candidate inventory and manifest grow with every session.
+#
+# Validate before promoting: launch with TRIAEVUM_PICA_CORPUS=1 and
+# TRIAEVUM_PICA_STRICT=1 and replay the recorded areas; any miss aborts the run.
+# Promote by copying pica-corpus/shader-inventory.json over
+# tools/oot3d/native_pica_frontend/profiles/oot3d_pica_boot_title_kokiri_pipeline.json
+# once the strict replay and a framebuffer comparison against dynamic generation
+# pass (docs/OOT3D_NRI_PICA_AOT_RENDERER_PARITY.md, "Extending coverage").
+if [[ $# -ne 2 ]]; then
+  printf 'Usage: bash %s INSTALLATION RUNTIME_BUILD\n' "$0" >&2
+  exit 2
+fi
+installation="$(realpath "$1")"
+runtime="$(realpath "$2")"
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+captures="$installation/linux-captures"
+baseline="$root/tools/oot3d/native_pica_frontend/profiles/oot3d_pica_boot_title_kokiri_pipeline.json"
+corpus="$runtime/pica-corpus"
+archive="$corpus/sessions/$(date +%Y%m%d-%H%M%S)"
+
+test -x "$runtime/oot3d_native_pica_aot_compiler"
+test -x "$runtime/oot3d_native_pica_pipeline_manifest"
+test -f "$captures/shader-inventory.json"
+mkdir -p "$archive"
+
+inventories=(--inventory "$baseline")
+[[ -f "$corpus/shader-inventory.json" ]] && inventories+=(--inventory "$corpus/shader-inventory.json")
+"$runtime/oot3d_native_pica_aot_compiler" \
+  "${inventories[@]}" --inventory "$captures/shader-inventory.json" \
+  --pack "$corpus/oot3d_pica_corpus.o3ps" --manifest "$corpus/oot3d_pica_corpus_manifest.json" \
+  --merged-inventory "$corpus/shader-inventory.json.new"
+mv "$corpus/shader-inventory.json.new" "$corpus/shader-inventory.json"
+
+if [[ -f "$captures/pipeline-inventory.json" ]]; then
+  pipelines=()
+  [[ -f "$corpus/oot3d_pica_corpus_pipelines.json" ]] && pipelines+=(--inventory "$corpus/oot3d_pica_corpus_pipelines.json")
+  "$runtime/oot3d_native_pica_pipeline_manifest" \
+    "${pipelines[@]}" --inventory "$captures/pipeline-inventory.json" \
+    --output "$corpus/oot3d_pica_corpus_pipelines.json.new"
+  mv "$corpus/oot3d_pica_corpus_pipelines.json.new" "$corpus/oot3d_pica_corpus_pipelines.json"
+fi
+# Archive the session so it is never merged twice and never lost.
+mv "$captures/shader-inventory.json" "$archive/"
+[[ -f "$captures/pipeline-inventory.json" ]] && mv "$captures/pipeline-inventory.json" "$archive/"
+printf 'Session archived to %s\n' "$archive"

--- a/scripts/run-linux-title.sh
+++ b/scripts/run-linux-title.sh
@@ -35,9 +35,53 @@ cd "$installation"
 mkdir -p linux-captures
 python3 "$root/tools/triaevum_release/prepare_linux_launch.py" \
   "$installation" "$title/triaevum_title_aot.so"
+# Default: the checked-in baseline pack. TRIAEVUM_PICA_CORPUS=1 selects the
+# local candidate built by scripts/extend-pica-corpus.sh (never the baseline).
+pack="$runtime/oot3d_pica_default.o3ps"
+pipelines=""
+if [[ "${TRIAEVUM_PICA_CORPUS:-0}" == 1 ]]; then
+  pack="$runtime/pica-corpus/oot3d_pica_corpus.o3ps"
+  pipelines="$runtime/pica-corpus/oot3d_pica_corpus_pipelines.json"
+  test -f "$pack"
+fi
 shader_args=()
-if [[ -f "$runtime/oot3d_pica_default.o3ps" ]]; then
-  shader_args+=(--pica-aot-shader-pack "$runtime/oot3d_pica_default.o3ps")
+# Forge-generated profiles may already carry the shipped pack (and prewarm
+# manifest); the runtime rejects duplicate options, so add ours only when the
+# profile has none and refuse a profile that already has more than one.
+pack_options=$(python3 - "$installation/TriAevum.linux.launch.json" <<'EOF'
+import json, sys
+try:
+    print(json.load(open(sys.argv[1]))["arguments"].count("--pica-aot-shader-pack"))
+except (OSError, ValueError, KeyError, AttributeError) as exc:
+    sys.exit(f"Launch profile is unusable: {exc}")
+EOF
+) || exit 2
+if [[ "$pack_options" -gt 1 ]]; then
+  printf 'Launch profile lists --pica-aot-shader-pack %s times\n' "$pack_options" >&2
+  exit 2
+fi
+if [[ -f "$pack" && "$pack_options" == 0 ]]; then
+  shader_args+=(--pica-aot-shader-pack "$pack")
+fi
+# Strict: any shader outside the pack aborts the run. Validation replay only.
+if [[ "${TRIAEVUM_PICA_STRICT:-0}" == 1 ]]; then
+  shader_args+=(--pica-aot-shader-strict)
+fi
+# Record every effective PICA shader and pipeline so the AOT pack and prewarm
+# manifest can be extended past the boot/title/Kokiri baseline
+# (see docs/OOT3D_NRI_PICA_AOT_RENDERER_PARITY.md). Written at renderer
+# shutdown: close the window normally, do not SIGTERM.
+if [[ "${TRIAEVUM_SHADER_INVENTORY:-0}" == 1 ]]; then
+  shader_args+=(--pica-effective-shader-inventory
+    "$installation/linux-captures/shader-inventory.json"
+    --pica-pipeline-inventory
+    "$installation/linux-captures/pipeline-inventory.json")
+fi
+# Create every manifest pipeline before the first frame instead of on first use.
+# Requires the candidate corpus: manifest and pack come from the same sessions.
+if [[ "${TRIAEVUM_PIPELINE_PREWARM:-0}" == 1 ]]; then
+  test -f "$pipelines"
+  shader_args+=(--pica-pipeline-manifest "$pipelines" --pica-pipeline-prewarm)
 fi
 capture_args=()
 # Readback deliberately stalls the device. Interactive previews must not pay
@@ -47,8 +91,10 @@ if [[ "${TRIAEVUM_CAPTURE_FRAMES:-0}" == 1 ]]; then
     --screenshot-start-frame 120 --screenshot-interval 300 --screenshot-sequence)
 fi
 # Keep the copied Windows profile unchanged; duplicate plugin options are forbidden.
+# stdout is block-buffered into the tee pipe; without misses to fill it the
+# progress lines never appear, so line-buffer it.
 timeout --signal=TERM --kill-after=5 "$((seconds + 30))" \
-  "$runtime/TriAevum" --launch-profile "$installation/TriAevum.linux.launch.json" \
+  stdbuf -oL "$runtime/TriAevum" --launch-profile "$installation/TriAevum.linux.launch.json" \
   "${shader_args[@]}" \
   --frames 0 --max-seconds "$seconds" \
   --output "$installation/linux-captures/runtime.json" \

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -4767,9 +4767,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                                             lastPresentationTime)
                   .count();
     lastPresentationTime = presentationTime;
-    const auto presentationStep =
-        presentationScheduler.Advance(presentationElapsedSeconds);
-    const uint32_t guestRefreshesDue = presentationStep.GuestRefreshesDue;
+    // Startup shader precompilation (Citra-style "preparing shaders"): hold
+    // the guest so no draw reaches a pipeline before it is created.
+    const bool shaderPrewarmHold =
+        api.NativePicaPipelinePrewarmProgress().Blocking;
+    const auto presentationStep = presentationScheduler.Advance(
+        shaderPrewarmHold ? 0.0 : presentationElapsedSeconds);
+    uint32_t guestRefreshesDue = presentationStep.GuestRefreshesDue;
     const float visualInterpolationAlpha = static_cast<float>(
         std::clamp(presentationStep.InterpolationAlpha, 0.0, 1.0));
     applyTopScreenConfigSnapshot();
@@ -4848,6 +4852,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     api.UpdateFramebufferParameters(0, width, height, 1, false, true, true,
                                     true);
     api.StartFrame();
+    // StartFrame may have detected a new renderer profile and queued its
+    // batch; drop this frame's refresh rather than let a draw race it.
+    if (api.NativePicaPipelinePrewarmProgress().Blocking) {
+      guestRefreshesDue = 0U;
+    }
     picaPresentationScheduler.BeginPresentation(presentationFrameCount);
     api.StartDrawToFramebuffer(0, 1.0F);
     api.SetClearColor(0.0F, 0.0F, 0.0F, 1.0F);


### PR DESCRIPTION
## Summary

Removes repeat first-encounter shader hitches on Linux/NRI by adopting the Citra/Azahar disk-cache model for the native PICA renderer: everything discovered at runtime is persisted per user and rebuilt before the first guest frame on the next launch, behind a "Preparing shaders N / M" overlay. Branched from `port/linux-nri` @ `1813090`.

This is the per-user half of the design. It does **not** give a brand-new install a hitch-free first pass; that needs a first-launch compile of the public inventory (see "Not in this PR").

## Runtime (`three_ds_recomp`)

- `GfxRenderingAPIVulkan`: every shader compiled at runtime (a miss in the shipped `.o3ps`) and every pipeline created at runtime is recorded and written at renderer shutdown to the SDL pref `oot3d_native_vulkan/shader_cache/` as `local_pica_shaders.o3ps` (SPIR-V, existing pack format) and `local_pica_pipelines.json` (existing manifest format). Both are hardware-independent; the driver `pipeline_cache.bin` keeps the per-GPU binaries. Descriptor-schema mismatch with the shipped pack discards the local cache.
- `PrewarmNativePicaPipelines` is now a queue over shipped + local manifests filtered by the active renderer profile, drained in budgeted slices (`OOT3D_PICA_PIPELINE_PREWARM_BUDGET_MS`, default 50) so the overlay stays responsive. `NativePicaPipelinePrewarmProgress()` is exposed on `GfxRenderingAPI`.
- `Fast3dGui::DrawMenu` draws the progress overlay while a batch is pending.
- `PicaGraphicsPipelineManifestEntry.OutlineOcclusionOnly`: the transparent-depth-overlay pipelines are keyed on this flag at runtime but the manifest could not represent it, so they were never prewarmable. Hash-compatible with existing manifests (only contributes when set); covered by a new round-trip test.
- `PicaAotShaderPack::Binaries()` for rewriting the local pack.
- Strict mode (`--pica-aot-shader-strict`) ignores the local cache so validation answers "does the selected pack cover this content". A strict miss previously segfaulted in `Shutdown()` (`EndNativePicaRenderPass` on a torn-down dynamic-rendering scope, Intel Mesa); shutdown now abandons an in-flight pass and the miss exits 1 with the error message.
- `local_hits` reported separately from shipped-pack `hits` in the resolution summary.

## Host

- `oot3d_native_a32_window.cpp`: the guest is not advanced while `Blocking` is set, re-checked after `StartFrame()` so the frame in which a renderer-profile change enqueues a batch is held too.

## Scripts / docs

- `scripts/run-linux-title.sh`: opt-ins for a local candidate corpus (`TRIAEVUM_PICA_CORPUS`), strict validation (`TRIAEVUM_PICA_STRICT`), prewarm (`TRIAEVUM_PIPELINE_PREWARM`) and shader/pipeline inventory recording (`TRIAEVUM_SHADER_INVENTORY`); adds `--pica-aot-shader-pack` only when the launch profile does not already carry one; `stdbuf -oL` so progress lines reach the tee'd log.
- `scripts/extend-pica-corpus.sh`: folds recorded sessions into a candidate pack + manifest under `<runtime>/pica-corpus/` (never touches the checked-in baseline; sessions archived).
- `docs/TRIAEVUM_LOCAL_SHADER_CACHE.md`: design mapping to Azahar (`vk_shader_disk_cache.cpp` / `vk_pipeline_cache.cpp`), limitations, verification.

## Verification (Intel Arc Meteor Lake, Mesa, clang, Release)

Fixed-step replays (`--frames 900 --fixed-delta-seconds 0.016666`) from an empty cache directory:

| run | prewarm | runtime shader compiles | runtime pipeline creations | exit |
|---|---|---|---|---|
| cold | — | 14 misses (12 new modules) | 47 | 0, cache written |
| warm ×3 | 47 pipelines in 13–26 ms before frame 1 | 0 | 0 | 0 |

- Interactive session: 100 pipelines cached on close; next launch prewarmed all 100 (33 + 29 ms) and ran with zero runtime compiles/creations.
- Strict + baseline pack + populated local cache: aborts on the first uncovered shader, exit 1 (was SIGSEGV). Strict + 322-module candidate corpus: 66/66, exit 0.
- `oot3d_pica_pipeline_manifest_tests`: 7/7 including the new compatibility case (built manually; see below).

## Not in this PR / known limits

- First-install precompute. The shipped `.o3ps` is game-derived and release-policy-forbidden, so Forge passes no pack; new users still compile on first encounter. The policy-compliant route is compiling the checked-in public inventory at first launch with the runtime's shaderc.
- Async compile / skip-draw (Azahar's optional fallback): deliberately omitted, it would break rendering parity.
- Persistence is at shutdown only; a crash loses that session's new entries.
- `runtime/three_ds_recomp/tests/CMakeLists.txt` does not build with Linux Clang (passes MSVC `/WX-` under `CMAKE_CXX_COMPILER_ID MATCHES Clang`; `oot3d_effect_graph_tests` lacks `Vulkan::Vulkan`). Not touched here; the doc records the manual test command.
- Overlay verified by execution path, not pixels (`--screenshot` captures the game framebuffer, not the composited swapchain).
