### PR TITLE
Show why a display change was reverted in the graphics settings window

### DIFF
--- a/runtime/three_ds_recomp/include/fast/oot3d/graphics_settings_runtime.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/graphics_settings_runtime.h
@@ -49,7 +49,10 @@ class GraphicsSettingsRuntime final {
     bool RetrySave();
     bool AcknowledgePresentationApplied(
         const GraphicsSettings& applied);
-    bool RejectPresentationApply(const GraphicsSettings& rejected);
+    bool RejectPresentationApply(const GraphicsSettings& rejected,
+                                 std::string reason = {});
+    // Why the last display change was rolled back; empty once a later change applies.
+    [[nodiscard]] std::string LastPresentationRejection() const;
     bool ConfirmPresentation();
     bool RollbackPresentation();
     bool TickPresentation();
@@ -68,5 +71,6 @@ class GraphicsSettingsRuntime final {
     bool mNativePresentationOverride = false;
     bool mPersistenceSuppressed = false;
     GraphicsSettingsSaveState mSaveState = GraphicsSettingsSaveState::Saved;
+    std::string mLastPresentationRejection;
 };
 } // namespace Fast::Oot3d

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
@@ -1735,7 +1735,7 @@ void GfxRenderingAPIVulkan::StartFrame() {
             if (presentationRequest->Kind ==
                 Oot3d::RendererPresentationRequestKind::Candidate) {
                 settingsRuntime.RejectPresentationApply(
-                    initialGraphicsSettings);
+                    initialGraphicsSettings, presentationError);
             }
             SPDLOG_ERROR("OOT3D display settings were not applied: {}",
                          presentationError);

--- a/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_runtime.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_runtime.cpp
@@ -462,6 +462,10 @@ bool GraphicsSettingsRuntime::RetrySave() {
     std::scoped_lock lock(mMutex);
     return PersistCurrentLocked();
 }
+std::string GraphicsSettingsRuntime::LastPresentationRejection() const {
+    std::scoped_lock lock(mMutex);
+    return mLastPresentationRejection;
+}
 bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     const GraphicsSettings& applied) {
     std::scoped_lock lock(mMutex);
@@ -470,6 +474,9 @@ bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     const bool acknowledged = mPresentationTransaction.MarkApplied(
         GetPresentationSettings(applied),
         PresentationClockMilliseconds());
+    if (acknowledged) {
+        mLastPresentationRejection.clear();
+    }
     if (acknowledged &&
         (phase == PresentationTransactionPhase::RollbackRequested ||
          mPresentationTransaction.Status(PresentationClockMilliseconds())
@@ -479,8 +486,9 @@ bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     return acknowledged;
 }
 bool GraphicsSettingsRuntime::RejectPresentationApply(
-    const GraphicsSettings& rejected) {
+    const GraphicsSettings& rejected, std::string reason) {
     std::scoped_lock lock(mMutex);
+    mLastPresentationRejection = std::move(reason);
     const auto status = mPresentationTransaction.Status(
         PresentationClockMilliseconds());
     if (GetPresentationSettings(rejected) !=

--- a/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_window.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_window.cpp
@@ -52,6 +52,10 @@ void GraphicsSettingsPanel::DrawPresentationStatus() {
     } else if (status.Phase == PresentationTransactionPhase::RollbackRequested) {
         ImGui::TextUnformatted("Restoring previous display settings...");
     }
+    if (const auto rejection = runtime.LastPresentationRejection();
+        !rejection.empty()) {
+        ImGui::TextWrapped("Display change reverted: %s", rejection.c_str());
+    }
     switch (runtime.SaveState()) {
         case GraphicsSettingsSaveState::Failed:
             ImGui::TextWrapped("Settings applied, but could not be saved.");


### PR DESCRIPTION
## Problem

Selecting **Exclusive fullscreen** in the F1 display settings goes fullscreen for under a second and snaps back to windowed, with no message. Reproduced on Linux (KDE Wayland, Intel/Mesa) and reported by the same tester on Windows. The presentation transaction is doing its job — `ApplyPresentationSettings` throws, the candidate is rolled back to last-known-good — but the only trace is an `SPDLOG_ERROR`, which the release logger level (`warn`) does not write, so neither the user nor the log shows *why*.

## Change

- `GraphicsSettingsRuntime::RejectPresentationApply` takes the apply error and stores it; `LastPresentationRejection()` exposes it, cleared when a later display change is acknowledged.
- `GfxRenderingAPIVulkan::StartFrame` passes `presentationError` on rejection.
- `GraphicsSettingsPanel::DrawPresentationStatus` prints `Display change reverted: <reason>`.

Diagnostic only; no change to the transaction, SDL backend or which modes are attempted.

## Not in this PR

The exclusive-fullscreen failure itself. The candidate causes are the flavor/mode checks in `ApplyPresentationSettings` (`IsWindowedFullscreen()` reads SDL flags immediately after `SDL_SetWindowFullscreen`, and Wayland reports desktop-fullscreen for both flavors) or `SetExclusiveFullscreenDisplayMode`; with this change the message identifies which. I tried making the SDL backend report the *requested* flavor instead of the SDL flags — it did not fix the revert, so it is not included.

`Borderless` works and persists on Linux; that is the current workaround.

Branched from `port/linux-nri` @ `1813090`; independent of #11 and #13.
