### PR TITLE
Native host loop: guest-thread split behind --guest-thread, with per-thread spans

### DIFF
--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -104,6 +104,26 @@ never runs ahead of input and audio buffering stays bounded.
    main rethrows at the join; main joins the guest thread before
    `WaitForAllPresents`/`vkDeviceWaitIdle` and before `process` destruction.
 
+## Measured (disjoint per-thread spans, 1200-frame uncapped runs)
+
+| per 1200 frames | single | `--guest-thread` |
+| --- | ---: | ---: |
+| guest drain (`RunUntilGuestWait` + PICA drain) | 10.5-11.9 s | 9.3-11.3 s |
+| guest step (clock, HID, DSP, VBlank) | 1.7 s | 1.5-1.8 s |
+| main present half | 2.5-3.0 s | 2.2-2.8 s |
+| main StartFrame (GPU fence/acquire wait) | 4.3-12.7 s | 6.8-18.0 s |
+| main waiting on guest | 0 | 8.8-10.5 s |
+| fps | 60.8 / 39.7 | 63.9 / 37.0 |
+
+The guest's cost is the drain (~9 ms/frame), not the step (~1.4 ms). The
+present half is ~2 ms, so overlapping it hides at most ~2 ms and main then
+waits on the guest; the loop is guest-bound (or GPU-bound when the iGPU clock
+is low, which doubles StartFrame in both modes). Frame rate is therefore within
+run-to-run noise. Reaching a gain requires overlapping `drain(k)` with
+`drain(k+1)`'s guest work, i.e. running the guest a full frame ahead behind a
+two-deep frame queue, at the cost of one presentation frame of input latency.
+That is the packet handoff above and is not implemented.
+
 ## Verification gate
 
 `--guest-thread` is accepted only when a deterministic replay

--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -69,9 +69,13 @@ same guest phase:
   and the probe flags (`nativeFrontendTouchEnabled`, native game mode) that
   main needs to poll input for `k+1`.
 
-Main waits for A before present-half and for B before rendering the HUD, so
-`step(k)` overlaps `StartFrame(k)` and `drain(k)+HUD(k)` overlaps
-present-half(k). Tokens (`guestRefreshesDue` from
+Main waits for A before present-half and for B before rendering the HUD.
+In the current implementation only `drain(k)+HUD(k)` overlaps
+present-half(k); `step(k)` still runs while main waits, because its input is
+polled after `StartFrame` and moving that poll earlier changes input phase
+relative to the single-thread path (the byte-identity gate). Overlapping the
+step with `StartFrame` is the next step and needs the explicit packet handoff
+below rather than shared loop locals. Tokens (`guestRefreshesDue` from
 `presentationScheduler.Advance`) and the polled `physicalInputFrame` are sent
 to the guest thread each presentation; the guest thread blocks on them, so it
 never runs ahead of input and audio buffering stays bounded.

--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -1,0 +1,110 @@
+# Guest thread: overlapping guest execution with rendering
+
+Status: design, implementation in progress on `feature/guest-thread`, gated by
+`--guest-thread` (default off).
+
+## Why
+
+Measured on a 6-minute Kokiri session (Linux, Intel Arc Meteor Lake, Mesa,
+Interpolated2x at 60 Hz, no captures):
+
+| phase | seconds | per presentation frame |
+| --- | ---: | ---: |
+| guest step (ARM11 whole-AOT, DSP, VBlank) | 61.4 | 5.0 ms |
+| visual presentation (PICA replay + Vulkan submit) | 60.3 | 4.9 ms |
+| StartFrame (present wait, fence, acquire, prewarm) | 62.7 | 5.1 ms |
+| plan build + submit bookkeeping | 18.4 | 1.5 ms |
+| pacer sleep | 135.5 | — |
+
+12,210 presentations in 359.7 s = 34 fps against a 60 Hz target, with 4,624
+deadline misses. Average CPU work is 16.6 ms per frame, exactly the budget, so
+variance alone produces the misses. One thread does everything; the other 21
+logical cores are idle (`/proc/<pid>/task/*/stat`: main 99.4%, next 1.0%).
+
+Azahar's answer is the same one used here: keep the guest serial (it is one
+ARM11 program) but run it on its own thread and let rendering overlap it.
+
+## What is already thread-safe
+
+- `Oot3dPicaVisualFrame` owns its data. Vertex/index/texture bytes are copied
+  out of guest memory into immutable `shared_ptr<const vector>` at submission
+  (`oot3d_native_pica_submission.cpp:259-311, 439-497`); no draw plan points
+  into guest RAM (`oot3d_native_pica_vulkan_plan.h`).
+- Guest-visible PICA completion is signaled at capture, never at GPU execution
+  (`oot3d_native_a32_window.cpp` drain loop), so the guest never waits on the
+  renderer.
+- `GrassInteractionBridge`, `GraphicsSettingsRuntime` and the submission queue
+  are mutex-guarded. The Vulkan present queue already runs on a worker.
+
+## Split
+
+Main thread keeps everything with a hard main-thread requirement: SDL event
+pump, ImGui, `api.StartFrame` (settings apply, swapchain recreate, prewarm),
+`window.EndFrame`, savestate execution, shutdown.
+
+A guest thread owns `process`, `hostServices`, `dspHle`, audio output,
+`submissionQueue` drain and plan build, the visual-frame accumulator
+(`Capture`/`FinishFrame`), `displayTransfersByOutput`, `uiLifecycleBridge`
+mutation and every guest-memory read the old loop performed between guest
+steps. It produces a `GuestPacket` per presentation.
+
+Per presentation `k`, the old loop was
+
+    probes(k) → poll input(k) → StartFrame → step(k) → present-half(k)
+    → drain(k) → HUD(k) → EndDraw → pacer → EndFrame
+
+where present-half(k) consumes frames from drain(k-1) and HUD(k) reads guest
+memory after drain(k). The new schedule keeps every guest-memory read at the
+same guest phase:
+
+    main:   poll input(k) ─┐                 present-half(k) ─┐  HUD(k)  EndDraw pacer EndFrame
+    guest:  [tokens(k), input(k)] step(k) → packet A(k) ─┘ drain(k) → HUD(k) → packet B(k) ─┘
+
+- `packet A` (after `step(k)` and `FinishFrame`): the finished
+  `Oot3dPicaVisualFrame` for the selected top transfer, the selected top and
+  bottom transfers, `LcdForceBlack`, `NativeFrontendPresentationActive`, the
+  scene view (`publishNativeSceneView` payload), and the actor interaction
+  publication for the grass bridge.
+- `packet B` (after `drain(k)`): TopScreen/shadow HUD primitives per subsystem
+  and the probe flags (`nativeFrontendTouchEnabled`, native game mode) that
+  main needs to poll input for `k+1`.
+
+Main waits for A before present-half and for B before rendering the HUD, so
+`step(k)` overlaps `StartFrame(k)` and `drain(k)+HUD(k)` overlaps
+present-half(k). Tokens (`guestRefreshesDue` from
+`presentationScheduler.Advance`) and the polled `physicalInputFrame` are sent
+to the guest thread each presentation; the guest thread blocks on them, so it
+never runs ahead of input and audio buffering stays bounded.
+
+`Oot3dPicaPresentationScheduler` is split: the accumulator (`Capture`,
+`FinishFrame`) becomes guest-thread state; `Execute`, `PresentExisting`,
+`HasSnapshot` and `mSnapshotCompletions` stay on main.
+
+## Hazards and how each is handled
+
+1. **Savestate / loadstate / PICA reset** span both halves. They run on main at
+   the join point after packet B with the guest thread parked; `loadState`
+   additionally clears both packets and the interpolation frame pair.
+2. **Frame-rate mode change** resets the previous/latest frame pair and the
+   continuity epoch on main. Packets carry the epoch they were produced under;
+   a packet from an older epoch is presented as a resynchronized current frame,
+   never interpolated against the new pair.
+3. **StartFrame stalls** (prewarm, swapchain recreate, present wait) delay the
+   join, so the guest thread simply waits for the next tokens; it cannot run
+   ahead. No guest-side mutex is ever held across a main-thread stall.
+4. **Interpolation pair lifetime**: `preparedVisualTransition` points into
+   `previousVisualFrame`/`latestVisualFrame`; both are main-owned, moved out of
+   packet A, and only reset on main.
+5. **Shutdown and errors**: `window.Close()` requests from the guest step and
+   exceptions inside it become a stop flag plus a stored `exception_ptr` that
+   main rethrows at the join; main joins the guest thread before
+   `WaitForAllPresents`/`vkDeviceWaitIdle` and before `process` destruction.
+
+## Verification gate
+
+`--guest-thread` is accepted only when a deterministic replay
+(`--fixed-delta-seconds 0.016666 --input-timeline …`) produces framebuffer
+captures byte-identical to the single-thread run at every checkpoint, the
+held-trigger and quick-state replays complete, and an interactive session
+shows the guest thread and main thread both busy in
+`/proc/<pid>/task/*/stat`.

--- a/scripts/run-linux-title.sh
+++ b/scripts/run-linux-title.sh
@@ -39,6 +39,10 @@ shader_args=()
 if [[ -f "$runtime/oot3d_pica_default.o3ps" ]]; then
   shader_args+=(--pica-aot-shader-pack "$runtime/oot3d_pica_default.o3ps")
 fi
+# Overlap guest execution with rendering on a second thread.
+if [[ "${TRIAEVUM_GUEST_THREAD:-0}" == 1 ]]; then
+  shader_args+=(--guest-thread)
+fi
 capture_args=()
 # Readback deliberately stalls the device. Interactive previews must not pay
 # for periodic captures; opt in explicitly when collecting image evidence.

--- a/tools/oot3d/native_demo_host/oot3d_demo_host_types.h
+++ b/tools/oot3d/native_demo_host/oot3d_demo_host_types.h
@@ -100,6 +100,8 @@ struct Args {
     // bootstrap supplies one complete simulation step per host frame while
     // the host disables VSync and its SDL software frame limiter.
     bool ThroughputBenchmark = false;
+    // Runs guest execution on its own thread so it overlaps rendering.
+    bool GuestThread = false;
     double MaxSeconds = 0.0;
     double FixedDeltaSeconds = 0.0;
     std::filesystem::path InputTimelinePath;

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -107,6 +107,11 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <condition_variable>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <thread>
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -3981,6 +3986,81 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 #endif
 
   NativeFramePhaseTiming phaseTiming;
+  // Runs one unit of guest work per presentation on a persistent thread and
+  // joins it before main touches guest state again. With the guest thread
+  // disabled the same units execute inline, so both modes share one loop.
+  struct GuestWorker {
+    explicit GuestWorker(bool threaded) : Threaded(threaded) {
+      if (Threaded) {
+        Thread = std::thread([this] {
+          for (;;) {
+            std::function<void()> unit;
+            {
+              std::unique_lock lock(Mutex);
+              Ready.wait(lock, [&] { return Pending != nullptr || Quit; });
+              if (Quit && Pending == nullptr) return;
+              unit = std::move(Pending);
+              Pending = nullptr;
+            }
+            try {
+              unit();
+            } catch (...) {
+              std::lock_guard lock(Mutex);
+              Failure = std::current_exception();
+            }
+            {
+              std::lock_guard lock(Mutex);
+              Busy = false;
+            }
+            Done.notify_all();
+          }
+        });
+      }
+    }
+    ~GuestWorker() {
+      if (Thread.joinable()) {
+        {
+          std::lock_guard lock(Mutex);
+          Quit = true;
+        }
+        Ready.notify_all();
+        Thread.join();
+      }
+    }
+    void Run(std::function<void()> unit) {
+      if (!Threaded) {
+        unit();
+        return;
+      }
+      {
+        std::lock_guard lock(Mutex);
+        Pending = std::move(unit);
+        Busy = true;
+      }
+      Ready.notify_all();
+    }
+    // Blocks until the unit finished; rethrows anything it threw.
+    void Wait() {
+      if (!Threaded) return;
+      std::exception_ptr failure;
+      {
+        std::unique_lock lock(Mutex);
+        Done.wait(lock, [&] { return !Busy; });
+        failure = std::exchange(Failure, nullptr);
+      }
+      if (failure) std::rethrow_exception(failure);
+    }
+    const bool Threaded;
+    std::thread Thread;
+    std::mutex Mutex;
+    std::condition_variable Ready;
+    std::condition_variable Done;
+    std::function<void()> Pending;
+    std::exception_ptr Failure;
+    bool Busy = false;
+    bool Quit = false;
+  } guestWorker(hostArgs.GuestThread);
+  bool guestStopRequested = false;
   Oot3dNativeGame::NativeA32InputDiagnostics inputDiagnostics;
   NativeInputConsumerDiagnostics inputConsumerDiagnostics;
   NativeControlPollingState nativeControlPollingState;
@@ -3993,6 +4073,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       Oot3dNativeGame::Oot3dUiProfileName(launch.UiProfile));
   Oot3dNativeGame::NativeA32DspHle dspHle(
       Oot3dNativeGame::BuildNativeA32DspPhysicalRegions(*manifest));
+  std::string hostLoopExitReason = "window_closed";
   auto *context = Ship::Context::GetRawInstance();
   auto audio = context != nullptr ? context->GetAudio() : nullptr;
   auto audioPlayer = audio != nullptr ? audio->GetAudioPlayer() : nullptr;
@@ -4405,30 +4486,41 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
   FramebufferScreenshotState screenshotState;
   uint64_t lastPublishedSceneViewSerial = 0;
   uint64_t publishedSceneViewCount = 0;
+  // Guest side captures the latest scene view; main publishes it to the
+  // renderer once per presentation, before the HUD, as it did inline.
+  std::optional<std::pair<uint64_t, Fast::Oot3d::TitleSceneViewSubmission>>
+      pendingSceneView;
   const auto publishNativeSceneView = [&]() {
     const auto snapshot = sceneViewProbe.Capture(process.Memory());
     if (!snapshot.has_value() ||
-        snapshot->Serial == lastPublishedSceneViewSerial) {
+        snapshot->Serial == lastPublishedSceneViewSerial ||
+        (pendingSceneView.has_value() &&
+         pendingSceneView->first == snapshot->Serial)) {
       return;
     }
-    const Fast::Oot3d::TitleSceneViewSubmission view{
-        snapshot->GuestFunction,
-        snapshot->GuestReturnAddress,
-        snapshot->Left,
-        snapshot->Right,
-        snapshot->Bottom,
-        snapshot->Top,
-        snapshot->NearPlane,
-        snapshot->FarPlane,
-        snapshot->Eye,
-        snapshot->At,
-        snapshot->CameraAvailable,
-    };
+    pendingSceneView = {snapshot->Serial,
+                        Fast::Oot3d::TitleSceneViewSubmission{
+                            snapshot->GuestFunction,
+                            snapshot->GuestReturnAddress,
+                            snapshot->Left,
+                            snapshot->Right,
+                            snapshot->Bottom,
+                            snapshot->Top,
+                            snapshot->NearPlane,
+                            snapshot->FarPlane,
+                            snapshot->Eye,
+                            snapshot->At,
+                            snapshot->CameraAvailable,
+                        }};
+  };
+  const auto flushSceneView = [&]() {
+    if (!pendingSceneView.has_value()) return;
     if (titleRenderBackend != nullptr &&
-        titleRenderBackend->PublishSceneView(view)) {
-      lastPublishedSceneViewSerial = snapshot->Serial;
+        titleRenderBackend->PublishSceneView(pendingSceneView->second)) {
+      lastPublishedSceneViewSerial = pendingSceneView->first;
       ++publishedSceneViewCount;
     }
+    pendingSceneView.reset();
   };
   picaPresentationScheduler.SetTimingEnabled(launch.ExtendedDiagnostics);
   std::optional<Fast::Oot3d::NativeFrameTemporalSample> capturedTemporalSample;
@@ -4831,6 +4923,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                            guestRefreshesDue != 0U,
                            nativeControlPollingState);
     if (physicalInputFrame.Exit) {
+      hostLoopExitReason = "host_input_exit";
       window.Close();
       break;
     }
@@ -4857,12 +4950,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     phaseTiming.FrameStartSeconds += SecondsSince(phaseStart);
     const uint32_t guestRefreshIterations =
         std::max<uint32_t>(1U, guestRefreshesDue);
-    for (uint32_t guestRefreshIndex = 0;
-         guestRefreshIndex < guestRefreshIterations; ++guestRefreshIndex) {
-      const bool advanceGuest = guestRefreshIndex < guestRefreshesDue;
-      const bool presentHostFrame =
-          guestRefreshIndex + 1U == guestRefreshIterations;
-      if (advanceGuest) {
+    // Guest unit 1: input routing and one guest step. Runs on the guest
+    // thread while main waits in StartFrame; touches no renderer state.
+    const auto guestStep = [&](uint32_t guestRefreshIndex) -> bool {
+      // Private to this unit: main uses its own phaseStart/error meanwhile.
+      auto phaseStart = std::chrono::steady_clock::now();
+      std::string error;
+      {
         if (guestRefreshIndex != 0U) {
           nativeFrontendTouchEnabled = ResolveNativeA32TouchInputEnabled(
               process.Memory(), uiLifecycleBridge,
@@ -4889,11 +4983,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             nativeCandidateDispatch.TopScreenStartRouting);
         inputDiagnostics.Observe(inputFrame);
         if (inputFrame.Exit) {
-          window.Close();
-          break;
+          guestStopRequested = true;
+          return false;
         }
       }
-      if (advanceGuest) {
+      {
         const uint32_t topScreenButtons = inputFrame.Hid.Buttons;
         const uint32_t topScreenPressed =
             topScreenButtons &
@@ -5154,13 +5248,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             std::cerr << "oot3d_native_game: structural scenario failed: "
                       << scenarioError << '\n';
             if (launch.ScenarioStrict) {
-              window.Close();
-              break;
+              guestStopRequested = true;
+              return false;
             }
           }
           if (launch.ScenarioAutoExit && scenarioBootstrap->Complete()) {
-            window.Close();
-            break;
+            guestStopRequested = true;
+            return false;
           }
         }
         refreshTickRemainder += kCtrArm11TicksPerSecond;
@@ -5250,60 +5344,84 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         }
         ++vblankCount;
       }
-      if (presentHostFrame) {
-        const auto visualPresentationStart = std::chrono::steady_clock::now();
-        const bool lcdForceBlack = hostServices.LcdForceBlack();
-        const auto topFramebuffer = hostServices.TopFramebuffer();
-        const Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission
-            *traceSelectedTopTransfer = nullptr;
-        if (topFramebuffer.has_value()) {
-          auto traceSelected =
-              displayTransfersByOutput.find(topFramebuffer->AddressLeft);
-          if (traceSelected == displayTransfersByOutput.end() &&
-              topFramebuffer->AddressRight != topFramebuffer->AddressLeft) {
-            traceSelected =
-                displayTransfersByOutput.find(topFramebuffer->AddressRight);
-          }
-          if (traceSelected != displayTransfersByOutput.end()) {
-            traceSelectedTopTransfer = &traceSelected->second;
-          }
+      return true;
+    };
+    // Everything the present half needs from guest-side state, gathered on
+    // main while the guest thread is idle. Present then overlaps the drain.
+    struct PresentInputs {
+      bool LcdForceBlack = false;
+      std::optional<Oot3dNativeGame::NativeA32CtrFramebufferState> Top;
+      std::optional<Oot3dNativeGame::NativeA32CtrFramebufferState> Bottom;
+      bool FrontendActive = false;
+      std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission>
+          SelectedTop;
+      std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission>
+          SelectedBottom;
+      std::optional<Oot3dNativeGame::Oot3dPicaVisualFrame> CurrentVisualFrame;
+      uint32_t GuestFrameCount = 0;
+    };
+    const auto gatherPresentInputs = [&]() {
+      PresentInputs in;
+      in.LcdForceBlack = hostServices.LcdForceBlack();
+      in.Top = hostServices.TopFramebuffer();
+      in.Bottom = hostServices.BottomFramebuffer();
+      in.FrontendActive = uiLifecycleBridge.NativeFrontendPresentationActive();
+      in.GuestFrameCount = frameCount;
+      const auto findTransfer = [&](uint32_t left, uint32_t right)
+          -> std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission> {
+        auto it = displayTransfersByOutput.find(left);
+        if (it == displayTransfersByOutput.end() && right != 0U && right != left) {
+          it = displayTransfersByOutput.find(right);
         }
-        picaSemanticTrace.RecordPresentationSelection(
-            presentationFrameCount, frameCount, lcdForceBlack,
-            topFramebuffer.has_value()
-                ? std::optional<uint32_t>(topFramebuffer->AddressLeft)
-                : std::nullopt,
-            topFramebuffer.has_value()
-                ? std::optional<uint32_t>(topFramebuffer->AddressRight)
-                : std::nullopt,
-            traceSelectedTopTransfer);
-        if (!lcdForceBlack) {
-          if (topFramebuffer.has_value()) {
-            auto selected =
-                displayTransfersByOutput.find(topFramebuffer->AddressLeft);
-            if (selected == displayTransfersByOutput.end() &&
-                topFramebuffer->AddressRight != topFramebuffer->AddressLeft) {
-              selected =
-                  displayTransfersByOutput.find(topFramebuffer->AddressRight);
-            }
-            if (selected != displayTransfersByOutput.end()) {
+        if (it == displayTransfersByOutput.end()) return std::nullopt;
+        return it->second;
+      };
+      if (in.Top.has_value()) {
+        in.SelectedTop = findTransfer(in.Top->AddressLeft, in.Top->AddressRight);
+      }
+      if (in.Bottom.has_value()) {
+        in.SelectedBottom =
+            findTransfer(in.Bottom->AddressLeft, in.Bottom->AddressRight);
+      }
+      picaSemanticTrace.RecordPresentationSelection(
+          presentationFrameCount, frameCount, in.LcdForceBlack,
+          in.Top.has_value() ? std::optional<uint32_t>(in.Top->AddressLeft)
+                             : std::nullopt,
+          in.Top.has_value() ? std::optional<uint32_t>(in.Top->AddressRight)
+                             : std::nullopt,
+          in.SelectedTop.has_value() ? &*in.SelectedTop : nullptr);
+      if (!in.LcdForceBlack && in.SelectedTop.has_value() &&
+          in.SelectedTop->CompletionId != lastSelectedTopTransferCompletionId) {
+        lastSelectedTopTransferCompletionId = in.SelectedTop->CompletionId;
+        ++selectedTopTransferCount;
+        in.CurrentVisualFrame =
+            picaPresentationScheduler.FinishFrame(*in.SelectedTop);
+        if (in.CurrentVisualFrame.has_value()) {
+          Oot3dNativeGame::PublishNativeActorInteractions(
+              process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress,
+              in.CurrentVisualFrame->Sequence);
+          Oot3dNativeGame::ComposeTopScreenFrontendFrame(
+              *in.CurrentVisualFrame,
+              Oot3dNativeGame::ShouldSuppressTopScreenFrontendBackdrop(
+                  launch.UiProfile, in.FrontendActive));
+        }
+      }
+      return in;
+    };
+    // Present half: only main-thread renderer state plus the snapshot.
+    const auto presentHalf = [&](PresentInputs &in) {
+      const auto visualPresentationStart = std::chrono::steady_clock::now();
+      {
+        if (!in.LcdForceBlack) {
+          if (in.SelectedTop.has_value()) {
+            const auto &selectedTop = *in.SelectedTop;
+            {
               bool presentedVisualSample = false;
               bool selectedNewVisualFrame = false;
-              if (selected->second.CompletionId !=
-                  lastSelectedTopTransferCompletionId) {
-                lastSelectedTopTransferCompletionId =
-                    selected->second.CompletionId;
-                ++selectedTopTransferCount;
-                auto currentVisualFrame =
-                    picaPresentationScheduler.FinishFrame(selected->second);
-                if (currentVisualFrame.has_value()) {
-                  Oot3dNativeGame::PublishNativeActorInteractions(
-                      process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress, currentVisualFrame->Sequence);
-                  Oot3dNativeGame::ComposeTopScreenFrontendFrame(
-                      *currentVisualFrame,
-                      Oot3dNativeGame::ShouldSuppressTopScreenFrontendBackdrop(
-                          launch.UiProfile,
-                          uiLifecycleBridge.NativeFrontendPresentationActive()));
+              if (in.CurrentVisualFrame.has_value()) {
+                auto currentVisualFrame = std::move(in.CurrentVisualFrame);
+                in.CurrentVisualFrame.reset();
+                {
                   selectedNewVisualFrame = true;
                   ++visualSnapshotCount;
                   auto &sample = visualFrameSampleScratch;
@@ -5395,7 +5513,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                               visualTransitionEvents.begin());
                         }
                         visualTransitionEvents.push_back({
-                            {"host_frame", frameCount},
+                            {"host_frame", in.GuestFrameCount},
                             {"previous_sequence",
                              latestVisualFrame->Sequence},
                             {"current_sequence",
@@ -5532,11 +5650,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
               }
               if (!presentedVisualSample &&
                   picaPresentationScheduler.HasSnapshot(
-                      selected->second,
+                      selectedTop,
                       kVisualInterpolationRenderTargetNamespace)) {
                 const auto started = std::chrono::steady_clock::now();
                 if (!picaPresentationScheduler.PresentExisting(
-                        api, selected->second,
+                        api, selectedTop,
                         kVisualInterpolationRenderTargetNamespace, &error)) {
                   throw std::runtime_error(
                       "native top-screen scheduled scanout failed: " + error);
@@ -5549,29 +5667,17 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 
           const bool presentNativeBottomFrontend =
               Oot3dNativeGame::ShouldPresentNativeBottomFrontend(
-                  launch.UiProfile,
-                  uiLifecycleBridge.NativeFrontendPresentationActive());
-          const auto bottomFramebuffer = hostServices.BottomFramebuffer();
-          if (presentNativeBottomFrontend &&
-              bottomFramebuffer.has_value()) {
+                  launch.UiProfile, in.FrontendActive);
+          if (presentNativeBottomFrontend && in.Bottom.has_value()) {
             ++nativeFrontendPresentationActiveCount;
-            auto selectedBottom =
-                displayTransfersByOutput.find(bottomFramebuffer->AddressLeft);
-            if (selectedBottom == displayTransfersByOutput.end() &&
-                bottomFramebuffer->AddressRight != 0U &&
-                bottomFramebuffer->AddressRight !=
-                    bottomFramebuffer->AddressLeft) {
-              selectedBottom = displayTransfersByOutput.find(
-                  bottomFramebuffer->AddressRight);
-            }
             nativeFrontendBottomTransferHitCount +=
-                selectedBottom != displayTransfersByOutput.end() ? 1U : 0U;
-            if (selectedBottom != displayTransfersByOutput.end() &&
+                in.SelectedBottom.has_value() ? 1U : 0U;
+            if (in.SelectedBottom.has_value() &&
                 picaPresentationScheduler.HasSnapshot(
-                    selectedBottom->second,
+                    *in.SelectedBottom,
                     kVisualInterpolationRenderTargetNamespace)) {
               if (!picaPresentationScheduler.PresentExisting(
-                      api, selectedBottom->second,
+                      api, *in.SelectedBottom,
                       kVisualInterpolationRenderTargetNamespace, &error)) {
                 throw std::runtime_error(
                     "native bottom-screen frontend presentation failed: " +
@@ -5584,7 +5690,15 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         phaseTiming.VisualPresentationSeconds +=
             SecondsSince(visualPresentationStart);
       }
-      if (advanceGuest) {
+    };
+    // Guest unit 2: run to the next wait and drain the PICA queue into the
+    // accumulator. Overlaps the present half; touches no renderer state
+    // except through the scene-view mailbox.
+    const auto guestDrain = [&]() {
+      // Private to this unit: main uses its own phaseStart/error meanwhile.
+      auto phaseStart = std::chrono::steady_clock::now();
+      std::string error;
+      {
         phaseStart = std::chrono::steady_clock::now();
         processResult =
             RunUntilGuestWait(process, launch.WholeAotBlockBudget);
@@ -6033,52 +6147,96 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         refreshesWithNativeDraws += refreshHadNativeDraws ? 1U : 0U;
         phaseTiming.PicaSubmitSeconds += SecondsSince(picaSubmitStart);
       }
-      frameCount += advanceGuest ? 1U : 0U;
-    }
-
-    if (launch.ExtendedDiagnostics) {
-      inputConsumerDiagnostics.Observe(process.Memory(), frameCount);
-    }
-
-    for (std::size_t subsystemIndex = 0;
-         subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
-      const auto subsystem =
-          static_cast<oot3d::ui::UiSubsystem>(subsystemIndex);
-      const bool topScreenProfile =
-          launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen;
-      if (topScreenProfile &&
-          subsystem != oot3d::ui::UiSubsystem::GameplayHud &&
-          subsystem != oot3d::ui::UiSubsystem::Map) {
-        continue;
+      ++frameCount;
+      if (launch.ExtendedDiagnostics) {
+        inputConsumerDiagnostics.Observe(process.Memory(), frameCount);
       }
-      const bool topScreenPresentation = topScreenProfile;
-      if (!topScreenPresentation && !uiLifecycleBridge.Runtime()
-                                         .PlanFrame(subsystem)
-                                         .run_host_presentation) {
-        continue;
+    };
+    // Guest unit 3: build UI primitives from guest memory. Runs after the
+    // drain on the guest thread; main renders them afterwards.
+    std::array<std::optional<std::vector<oot3d::ui::UiPrimitive>>,
+               oot3d::ui::kUiSubsystemCount>
+        hudPrimitives;
+    const auto buildHud = [&]() {
+      for (std::size_t subsystemIndex = 0;
+           subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
+        hudPrimitives[subsystemIndex].reset();
+        const auto subsystem =
+            static_cast<oot3d::ui::UiSubsystem>(subsystemIndex);
+        const bool topScreenProfile =
+            launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen;
+        if (topScreenProfile &&
+            subsystem != oot3d::ui::UiSubsystem::GameplayHud &&
+            subsystem != oot3d::ui::UiSubsystem::Map) {
+          continue;
+        }
+        if (!topScreenProfile && !uiLifecycleBridge.Runtime()
+                                      .PlanFrame(subsystem)
+                                      .run_host_presentation) {
+          continue;
+        }
+        auto primitives =
+            topScreenProfile
+                ? uiLifecycleBridge.BuildTopScreenPresentation(subsystem)
+                : uiLifecycleBridge.BuildShadowPresentation(subsystem);
+        if (topScreenProfile &&
+            subsystem == oot3d::ui::UiSubsystem::GameplayHud) {
+          Oot3dNativeGame::AppendTopScreenFreeCameraOptionPresentation(
+              nativeCandidateDispatch.TopScreenCamera.Camera, primitives);
+        }
+        if (topScreenProfile) {
+          lastTopScreenPrimitivesBySubsystem[subsystemIndex] = primitives;
+        }
+        hudPrimitives[subsystemIndex] = std::move(primitives);
       }
-      auto primitives =
-          topScreenPresentation
-              ? uiLifecycleBridge.BuildTopScreenPresentation(subsystem)
-              : uiLifecycleBridge.BuildShadowPresentation(subsystem);
-      if (topScreenPresentation &&
-          subsystem == oot3d::ui::UiSubsystem::GameplayHud) {
-        Oot3dNativeGame::AppendTopScreenFreeCameraOptionPresentation(
-            nativeCandidateDispatch.TopScreenCamera.Camera, primitives);
-      }
-      if (topScreenPresentation) {
-        lastTopScreenPrimitivesBySubsystem[subsystemIndex] = primitives;
-      }
+    };
+    const auto renderHud = [&]() {
       const auto canvasMode =
-          topScreenPresentation
+          launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen
               ? oot3d::ui::N64UiCanvasMode::NativeTopScreen400x240
               : oot3d::ui::N64UiCanvasMode::Widescreen16x9;
-      if (!n64UiRenderer.Render(primitives, width, height, canvasMode,
-                                &error)) {
-        throw std::runtime_error("integrated N64 UI presentation failed: " +
-                                 error);
+      for (auto &primitives : hudPrimitives) {
+        if (!primitives.has_value()) continue;
+        if (!n64UiRenderer.Render(*primitives, width, height, canvasMode,
+                                  &error)) {
+          throw std::runtime_error("integrated N64 UI presentation failed: " +
+                                   error);
+        }
       }
+    };
+
+    // Sequence per presentation. Units run inline unless --guest-thread.
+    //   guest:  step(0) ... step(n-1)+drain   |   present inputs   |   drain(n) + HUD build
+    //   main:   StartFrame (already done)     |   (guest idle)     |   present half
+    // Guest-memory reads keep their original phase relative to guest steps.
+    guestStopRequested = false;
+    guestWorker.Run([&] {
+      for (uint32_t guestRefreshIndex = 0;
+           guestRefreshIndex + 1U < guestRefreshesDue; ++guestRefreshIndex) {
+        if (!guestStep(guestRefreshIndex)) return;
+        guestDrain();
+      }
+      if (guestRefreshesDue != 0U) {
+        guestStep(guestRefreshesDue - 1U);
+      }
+    });
+    guestWorker.Wait();
+    if (guestStopRequested) {
+      hostLoopExitReason = "guest_requested_stop";
+      window.Close();
+      break;
     }
+    PresentInputs presentInputs = gatherPresentInputs();
+    guestWorker.Run([&] {
+      if (guestRefreshesDue != 0U) {
+        guestDrain();
+      }
+      buildHud();
+    });
+    presentHalf(presentInputs);
+    guestWorker.Wait();
+    flushSceneView();
+    renderHud();
 
     phaseStart = std::chrono::steady_clock::now();
     gui->EndDraw();
@@ -6473,6 +6631,8 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             {"run_frames", runFrameCount},
             {"guest_refresh_frames", frameCount},
             {"presentation_frames", presentationFrameCount},
+            {"host_loop_exit_reason", hostLoopExitReason},
+            {"guest_thread", hostArgs.GuestThread},
             {"pica_composition",
              [&]() {
                const auto &stats = picaCompositionTracker.Stats();

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -541,6 +541,18 @@ struct NativeFramePhaseTiming {
   double PresentSeconds = 0.0;
 };
 
+// Wall-clock spans that partition each thread's time. Main's spans plus its
+// waits sum to the host loop; the guest thread's spans are disjoint from them.
+struct NativeThreadSpanTiming {
+  double MainStartFrameSeconds = 0.0;
+  double MainPresentHalfSeconds = 0.0;
+  double MainHudAndEndFrameSeconds = 0.0;
+  double MainWaitForGuestSeconds = 0.0;
+  double GuestStepSeconds = 0.0;
+  double GuestDrainSeconds = 0.0;
+  double GuestHudBuildSeconds = 0.0;
+};
+
 struct NativeAudioOutputDiagnostics {
   void Observe(uint32_t hostFrame, int32_t before, int32_t after,
                uint64_t requestedFrames, int32_t desiredBuffered) {
@@ -3986,6 +3998,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 #endif
 
   NativeFramePhaseTiming phaseTiming;
+  NativeThreadSpanTiming spanTiming;
   // Runs one unit of guest work per presentation on a persistent thread and
   // joins it before main touches guest state again. With the guest thread
   // disabled the same units execute inline, so both modes share one loop.
@@ -4806,6 +4819,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     widescreenProjection.CurrentHostFrame =
         static_cast<uint32_t>(presentationFrameCount);
     WindowDemoFrameTiming frameTiming;
+    const auto mainFrameStart = std::chrono::steady_clock::now();
     if (!PrepareNextWindowDemoFrame(hostArgs, window, timing, frameTiming)) {
       continue;
     }
@@ -4948,11 +4962,17 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     api.SetViewport(0, 0, static_cast<int>(width), static_cast<int>(height));
     api.SetScissor(0, 0, static_cast<int>(width), static_cast<int>(height));
     phaseTiming.FrameStartSeconds += SecondsSince(phaseStart);
+    spanTiming.MainStartFrameSeconds += SecondsSince(mainFrameStart);
     const uint32_t guestRefreshIterations =
         std::max<uint32_t>(1U, guestRefreshesDue);
     // Guest unit 1: input routing and one guest step. Runs on the guest
     // thread while main waits in StartFrame; touches no renderer state.
     const auto guestStep = [&](uint32_t guestRefreshIndex) -> bool {
+      const auto spanStart = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{spanStart, spanTiming.GuestStepSeconds};
       // Private to this unit: main uses its own phaseStart/error meanwhile.
       auto phaseStart = std::chrono::steady_clock::now();
       std::string error;
@@ -5695,6 +5715,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     // accumulator. Overlaps the present half; touches no renderer state
     // except through the scene-view mailbox.
     const auto guestDrain = [&]() {
+      const auto spanStart = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{spanStart, spanTiming.GuestDrainSeconds};
       // Private to this unit: main uses its own phaseStart/error meanwhile.
       auto phaseStart = std::chrono::steady_clock::now();
       std::string error;
@@ -6158,6 +6183,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                oot3d::ui::kUiSubsystemCount>
         hudPrimitives;
     const auto buildHud = [&]() {
+      const auto t0 = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{t0, spanTiming.GuestHudBuildSeconds};
       for (std::size_t subsystemIndex = 0;
            subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
         hudPrimitives[subsystemIndex].reset();
@@ -6220,7 +6250,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         guestStep(guestRefreshesDue - 1U);
       }
     });
-    guestWorker.Wait();
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      guestWorker.Wait();
+      spanTiming.MainWaitForGuestSeconds += SecondsSince(t0);
+    }
     if (guestStopRequested) {
       hostLoopExitReason = "guest_requested_stop";
       window.Close();
@@ -6233,8 +6267,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       }
       buildHud();
     });
-    presentHalf(presentInputs);
-    guestWorker.Wait();
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      presentHalf(presentInputs);
+      spanTiming.MainPresentHalfSeconds += SecondsSince(t0);
+    }
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      guestWorker.Wait();
+      spanTiming.MainWaitForGuestSeconds += SecondsSince(t0);
+    }
     flushSceneView();
     renderHud();
 
@@ -6250,6 +6292,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     picaSemanticTrace.RecordFrameBoundary(
         presentationFrameCount, frameCount, guestRefreshesDue != 0U);
     phaseTiming.PresentSeconds += SecondsSince(phaseStart);
+    spanTiming.MainHudAndEndFrameSeconds += SecondsSince(phaseStart);
     ++presentationFrameCount;
     ++runFrameCount;
 #if defined(__SWITCH__)
@@ -8982,6 +9025,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             {"phase_timing",
              {{"guest_seconds", phaseTiming.GuestSeconds},
               {"frame_start_seconds", phaseTiming.FrameStartSeconds},
+              {"thread_spans",
+               {{"main_start_frame_seconds", spanTiming.MainStartFrameSeconds},
+                {"main_present_half_seconds", spanTiming.MainPresentHalfSeconds},
+                {"main_hud_and_end_frame_seconds",
+                 spanTiming.MainHudAndEndFrameSeconds},
+                {"main_wait_for_guest_seconds",
+                 spanTiming.MainWaitForGuestSeconds},
+                {"guest_step_seconds", spanTiming.GuestStepSeconds},
+                {"guest_drain_seconds", spanTiming.GuestDrainSeconds},
+                {"guest_hud_build_seconds", spanTiming.GuestHudBuildSeconds}}},
               {"dsp_mix_seconds", phaseTiming.DspMixSeconds},
               {"audio_output_seconds", phaseTiming.AudioOutputSeconds},
               {"pica_submit_seconds", phaseTiming.PicaSubmitSeconds},

--- a/tools/oot3d/native_game_runtime/oot3d_native_game_bootstrap.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_game_bootstrap.cpp
@@ -727,6 +727,8 @@ bool ParseOot3dNativeGameArgs(int argc, char** argv, Oot3dNativeGameLaunch& laun
                 ParseU32(argv[++index], "benchmark warm-up frame count");
         } else if (arg == "--throughput-benchmark") {
             launch.Host.ThroughputBenchmark = true;
+        } else if (arg == "--guest-thread") {
+            launch.Host.GuestThread = true;
         } else if (arg == "--max-seconds" && index + 1 < argc) {
             launch.Host.MaxSeconds = std::max(0.0, ParseDouble(argv[++index], "maximum seconds"));
         } else if (arg == "--fixed-delta-seconds" && index + 1 < argc) {


### PR DESCRIPTION
## What this is

The native game host loop (`oot3d_native_a32_window.cpp`) currently does guest step, PICA drain, visual replay/submit, HUD build and present on one thread; measured live, one thread sits at ~99% of a core while the other 21 idle. This PR splits the loop into units and, behind `--guest-thread` (default off; `TRIAEVUM_GUEST_THREAD=1` in `run-linux-title.sh`), runs the guest units on a persistent worker while main stays the SDL/ImGui/Vulkan/present thread. With the flag off the same units execute inline in the original order, so both modes share one loop.

Units: `guestStep` (clock/HID/DSP/VBlank), `gatherPresentInputs` (value snapshot of every guest/host read the present half needs, taken on main while the worker is idle), `presentHalf` (renderer-only, consumes the snapshot), `guestDrain` (`RunUntilGuestWait` + PICA drain into the accumulator), `buildHud` (guest-memory reads → primitives), `renderHud` (main). The scene view goes through a mailbox flushed on main before the HUD. Guest exits/exceptions become a stop flag + `exception_ptr` rethrown on main; savestate/load run at the join with the worker idle.

`runtime.json` gains `host_loop_exit_reason`, `guest_thread`, and `phase_timing.thread_spans` — **disjoint** per-thread wall-clock spans (the existing `phase_timing` scopes overlap and cannot be summed).

## What it verifiably does

- Deterministic replay (gameplay quick state + 1-frame tap input timeline, fixed delta): framebuffer captures **byte-identical at 7/7 checkpoints** to the pre-refactor baseline, in both single-thread and `--guest-thread` modes. The baseline itself was first shown deterministic run-to-run.
- Held-trigger replay, mid-run `--save-state` + reload, and `Original30` replays complete in threaded mode (`host_loop_exit_reason: window_closed`).
- Interactive session on the flag: two busy threads instead of one; no hangs.

## What it does not do (measured, not inferred)

Only `drain(k)` + HUD build overlap `presentHalf(k)`. Disjoint spans over 1200-frame uncapped runs, interleaved single/threaded:

| per 1200 frames | single | threaded |
|---|---:|---:|
| guest drain | 10.5–11.9 s | 9.3–11.3 s |
| guest step | 1.7 s | 1.5–1.8 s |
| main present half | 2.5–3.0 s | 2.2–2.8 s |
| main StartFrame (GPU wait) | 4.3–12.7 s | 6.8–18.0 s |
| main waiting on guest | 0 | 8.8–10.5 s |
| fps | 60.8 / 39.7 | 63.9 / 37.0 |

The guest cost lives in the drain (~9 ms/frame), the present half is ~2 ms, so overlap hides ≤2 ms and main waits on the guest. The loop is guest-bound (or GPU-bound when the iGPU clock drops — StartFrame doubles in both modes). **Frame rate is within noise.** A real gain needs the guest running a frame ahead behind a two-deep frame queue (`docs/TRIAEVUM_GUEST_THREAD.md`, packet handoff), which costs one presentation frame of input latency and is not implemented here.

## Why open it anyway

- The refactor is behaviour-preserving (byte-identical gate) and makes the guest/renderer boundary explicit — every guest-memory read the present half needs is now in `PresentInputs`, every renderer call the guest half made is now a mailbox.
- The spans are the first non-overlapping measurement of where the loop's time goes, on any platform.
- The flag is off by default; nothing changes for users.

## Known gap

The units capture loop locals by reference and rely on sequencing (main never touches guest-owned locals while a unit is in flight) rather than ownership. The byte-identity gate is consistent with that but does not prove it; the value-owned packet handoff in the design doc is the follow-up that makes it structural, and is the same change the frame-ahead queue needs.

Branched from `port/linux-nri` @ `1813090`; independent of #11/#13/#14.
