### PR TITLE
Show the ocarina UI on the single screen, TopScreen-mod style

### DIFF
--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -104,6 +104,26 @@ never runs ahead of input and audio buffering stays bounded.
    main rethrows at the join; main joins the guest thread before
    `WaitForAllPresents`/`vkDeviceWaitIdle` and before `process` destruction.
 
+## Measured (disjoint per-thread spans, 1200-frame uncapped runs)
+
+| per 1200 frames | single | `--guest-thread` |
+| --- | ---: | ---: |
+| guest drain (`RunUntilGuestWait` + PICA drain) | 10.5-11.9 s | 9.3-11.3 s |
+| guest step (clock, HID, DSP, VBlank) | 1.7 s | 1.5-1.8 s |
+| main present half | 2.5-3.0 s | 2.2-2.8 s |
+| main StartFrame (GPU fence/acquire wait) | 4.3-12.7 s | 6.8-18.0 s |
+| main waiting on guest | 0 | 8.8-10.5 s |
+| fps | 60.8 / 39.7 | 63.9 / 37.0 |
+
+The guest's cost is the drain (~9 ms/frame), not the step (~1.4 ms). The
+present half is ~2 ms, so overlapping it hides at most ~2 ms and main then
+waits on the guest; the loop is guest-bound (or GPU-bound when the iGPU clock
+is low, which doubles StartFrame in both modes). Frame rate is therefore within
+run-to-run noise. Reaching a gain requires overlapping `drain(k)` with
+`drain(k+1)`'s guest work, i.e. running the guest a full frame ahead behind a
+two-deep frame queue, at the cost of one presentation frame of input latency.
+That is the packet handoff above and is not implemented.
+
 ## Verification gate
 
 `--guest-thread` is accepted only when a deterministic replay

--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -69,9 +69,13 @@ same guest phase:
   and the probe flags (`nativeFrontendTouchEnabled`, native game mode) that
   main needs to poll input for `k+1`.
 
-Main waits for A before present-half and for B before rendering the HUD, so
-`step(k)` overlaps `StartFrame(k)` and `drain(k)+HUD(k)` overlaps
-present-half(k). Tokens (`guestRefreshesDue` from
+Main waits for A before present-half and for B before rendering the HUD.
+In the current implementation only `drain(k)+HUD(k)` overlaps
+present-half(k); `step(k)` still runs while main waits, because its input is
+polled after `StartFrame` and moving that poll earlier changes input phase
+relative to the single-thread path (the byte-identity gate). Overlapping the
+step with `StartFrame` is the next step and needs the explicit packet handoff
+below rather than shared loop locals. Tokens (`guestRefreshesDue` from
 `presentationScheduler.Advance`) and the polled `physicalInputFrame` are sent
 to the guest thread each presentation; the guest thread blocks on them, so it
 never runs ahead of input and audio buffering stays bounded.

--- a/docs/TRIAEVUM_GUEST_THREAD.md
+++ b/docs/TRIAEVUM_GUEST_THREAD.md
@@ -1,0 +1,110 @@
+# Guest thread: overlapping guest execution with rendering
+
+Status: design, implementation in progress on `feature/guest-thread`, gated by
+`--guest-thread` (default off).
+
+## Why
+
+Measured on a 6-minute Kokiri session (Linux, Intel Arc Meteor Lake, Mesa,
+Interpolated2x at 60 Hz, no captures):
+
+| phase | seconds | per presentation frame |
+| --- | ---: | ---: |
+| guest step (ARM11 whole-AOT, DSP, VBlank) | 61.4 | 5.0 ms |
+| visual presentation (PICA replay + Vulkan submit) | 60.3 | 4.9 ms |
+| StartFrame (present wait, fence, acquire, prewarm) | 62.7 | 5.1 ms |
+| plan build + submit bookkeeping | 18.4 | 1.5 ms |
+| pacer sleep | 135.5 | — |
+
+12,210 presentations in 359.7 s = 34 fps against a 60 Hz target, with 4,624
+deadline misses. Average CPU work is 16.6 ms per frame, exactly the budget, so
+variance alone produces the misses. One thread does everything; the other 21
+logical cores are idle (`/proc/<pid>/task/*/stat`: main 99.4%, next 1.0%).
+
+Azahar's answer is the same one used here: keep the guest serial (it is one
+ARM11 program) but run it on its own thread and let rendering overlap it.
+
+## What is already thread-safe
+
+- `Oot3dPicaVisualFrame` owns its data. Vertex/index/texture bytes are copied
+  out of guest memory into immutable `shared_ptr<const vector>` at submission
+  (`oot3d_native_pica_submission.cpp:259-311, 439-497`); no draw plan points
+  into guest RAM (`oot3d_native_pica_vulkan_plan.h`).
+- Guest-visible PICA completion is signaled at capture, never at GPU execution
+  (`oot3d_native_a32_window.cpp` drain loop), so the guest never waits on the
+  renderer.
+- `GrassInteractionBridge`, `GraphicsSettingsRuntime` and the submission queue
+  are mutex-guarded. The Vulkan present queue already runs on a worker.
+
+## Split
+
+Main thread keeps everything with a hard main-thread requirement: SDL event
+pump, ImGui, `api.StartFrame` (settings apply, swapchain recreate, prewarm),
+`window.EndFrame`, savestate execution, shutdown.
+
+A guest thread owns `process`, `hostServices`, `dspHle`, audio output,
+`submissionQueue` drain and plan build, the visual-frame accumulator
+(`Capture`/`FinishFrame`), `displayTransfersByOutput`, `uiLifecycleBridge`
+mutation and every guest-memory read the old loop performed between guest
+steps. It produces a `GuestPacket` per presentation.
+
+Per presentation `k`, the old loop was
+
+    probes(k) → poll input(k) → StartFrame → step(k) → present-half(k)
+    → drain(k) → HUD(k) → EndDraw → pacer → EndFrame
+
+where present-half(k) consumes frames from drain(k-1) and HUD(k) reads guest
+memory after drain(k). The new schedule keeps every guest-memory read at the
+same guest phase:
+
+    main:   poll input(k) ─┐                 present-half(k) ─┐  HUD(k)  EndDraw pacer EndFrame
+    guest:  [tokens(k), input(k)] step(k) → packet A(k) ─┘ drain(k) → HUD(k) → packet B(k) ─┘
+
+- `packet A` (after `step(k)` and `FinishFrame`): the finished
+  `Oot3dPicaVisualFrame` for the selected top transfer, the selected top and
+  bottom transfers, `LcdForceBlack`, `NativeFrontendPresentationActive`, the
+  scene view (`publishNativeSceneView` payload), and the actor interaction
+  publication for the grass bridge.
+- `packet B` (after `drain(k)`): TopScreen/shadow HUD primitives per subsystem
+  and the probe flags (`nativeFrontendTouchEnabled`, native game mode) that
+  main needs to poll input for `k+1`.
+
+Main waits for A before present-half and for B before rendering the HUD, so
+`step(k)` overlaps `StartFrame(k)` and `drain(k)+HUD(k)` overlaps
+present-half(k). Tokens (`guestRefreshesDue` from
+`presentationScheduler.Advance`) and the polled `physicalInputFrame` are sent
+to the guest thread each presentation; the guest thread blocks on them, so it
+never runs ahead of input and audio buffering stays bounded.
+
+`Oot3dPicaPresentationScheduler` is split: the accumulator (`Capture`,
+`FinishFrame`) becomes guest-thread state; `Execute`, `PresentExisting`,
+`HasSnapshot` and `mSnapshotCompletions` stay on main.
+
+## Hazards and how each is handled
+
+1. **Savestate / loadstate / PICA reset** span both halves. They run on main at
+   the join point after packet B with the guest thread parked; `loadState`
+   additionally clears both packets and the interpolation frame pair.
+2. **Frame-rate mode change** resets the previous/latest frame pair and the
+   continuity epoch on main. Packets carry the epoch they were produced under;
+   a packet from an older epoch is presented as a resynchronized current frame,
+   never interpolated against the new pair.
+3. **StartFrame stalls** (prewarm, swapchain recreate, present wait) delay the
+   join, so the guest thread simply waits for the next tokens; it cannot run
+   ahead. No guest-side mutex is ever held across a main-thread stall.
+4. **Interpolation pair lifetime**: `preparedVisualTransition` points into
+   `previousVisualFrame`/`latestVisualFrame`; both are main-owned, moved out of
+   packet A, and only reset on main.
+5. **Shutdown and errors**: `window.Close()` requests from the guest step and
+   exceptions inside it become a stop flag plus a stored `exception_ptr` that
+   main rethrows at the join; main joins the guest thread before
+   `WaitForAllPresents`/`vkDeviceWaitIdle` and before `process` destruction.
+
+## Verification gate
+
+`--guest-thread` is accepted only when a deterministic replay
+(`--fixed-delta-seconds 0.016666 --input-timeline …`) produces framebuffer
+captures byte-identical to the single-thread run at every checkpoint, the
+held-trigger and quick-state replays complete, and an interactive session
+shows the guest thread and main thread both busy in
+`/proc/<pid>/task/*/stat`.

--- a/docs/TRIAEVUM_LOCAL_SHADER_CACHE.md
+++ b/docs/TRIAEVUM_LOCAL_SHADER_CACHE.md
@@ -1,0 +1,78 @@
+# Per-user shader cache and startup prewarm
+
+TriAevum generates host shaders from live PICA state, so the shader set cannot be
+enumerated ahead of time. The runtime now removes *repeat* hitches the way
+Citra/Azahar do (`src/video_core/renderer_vulkan/vk_shader_disk_cache.cpp`,
+`vk_pipeline_cache.cpp`): persist what was discovered, and rebuild all of it
+before the game runs. A brand-new install still compiles on first encounter;
+closing that gap needs a first-launch compile of the public inventory, which is
+not implemented.
+
+| Azahar | TriAevum |
+| --- | --- |
+| transferable cache: shader configs + SPIR-V + pipeline configs, per title | `local_pica_shaders.o3ps` (SPIR-V, keyed by shader source identity) and `local_pica_pipelines.json` (complete pipeline state incl. shader identities) under the SDL pref path `oot3d_native_vulkan/shader_cache/` |
+| driver pipeline cache per vendor/device | `pipeline_cache.bin`, validated against vendor/device/UUID (pre-existing) |
+| `InitPLCache` rebuilds every pipeline behind a load callback | `PrewarmNativePicaPipelines` builds every entry matching the active renderer profile; the guest is held and an ImGui "Preparing shaders N / M" overlay is drawn until the batch drains |
+| async `TryBuild(false)` skip-draw fallback | not implemented; a pipeline created on a draw is the hitch being removed, and skipped draws would break rendering parity |
+
+## Runtime behaviour
+
+- Every shader compiled at runtime (a miss in the shipped pack) and every pipeline
+  created at runtime is recorded; both files are rewritten at renderer shutdown.
+  Close the game normally to persist a session. A crash loses that session's new
+  entries (not the existing cache); append-on-discovery is deferred until the
+  I/O cost is measured off the render thread.
+- On the next launch the cache is loaded, then `Fast3dGui` shows the overlay while
+  `GfxRenderingAPIVulkan::StartFrame` creates the pipelines in budgeted slices
+  (`OOT3D_PICA_PIPELINE_PREWARM_BUDGET_MS`, default 50). The native host loop
+  (`oot3d_native_a32_window.cpp`) advances no guest frame while
+  `NativePicaPipelinePrewarmProgress().Blocking` is set, including the frame in
+  which a renderer-profile change enqueues a new batch.
+- Both files carry the descriptor schema; a mismatch with the shipped pack
+  discards the local cache. Stale entries are harmless: unknown shader
+  identities simply never match.
+- `OOT3D_PICA_LOCAL_SHADER_CACHE=0` disables the cache. `--pica-aot-shader-strict`
+  disables it implicitly: strict validation must answer whether the selected pack
+  covers the content, not whether this machine has seen it before.
+- The shipped `.o3ps` pack and an optional `--pica-pipeline-manifest` +
+  `--pica-pipeline-prewarm` pair use the same prewarm queue. The pack is
+  game-derived and is forbidden from public release payloads
+  (`tools/triaevum_release/release_policy.json`), which is why Forge does not pass
+  one; the per-user cache is what every user gets today, for content already seen.
+
+## Extending a shared corpus locally
+
+`scripts/run-linux-title.sh` records inventories with `TRIAEVUM_SHADER_INVENTORY=1`
+and `scripts/extend-pica-corpus.sh` folds them into a candidate pack and manifest
+under `<runtime>/pica-corpus/`. Launch with `TRIAEVUM_PICA_CORPUS=1`
+(+ `TRIAEVUM_PICA_STRICT=1` to validate, `TRIAEVUM_PIPELINE_PREWARM=1` to prewarm).
+
+The manifest schema change is covered by
+`tests/oot3d_pica_pipeline_manifest_tests.cpp`
+(`OutlineOcclusionFlagIsCompatibleWithOlderManifests`). The `tests/` CMake tree
+currently does not build with Linux Clang (it passes the MSVC-only `/WX-` flag to
+any Clang, and `oot3d_effect_graph_tests` lacks a `Vulkan::Vulkan` dependency);
+until that is fixed, build the target's source list directly against system gtest
+and nlohmann/json:
+
+```sh
+cd runtime/three_ds_recomp && clang++ -std=c++20 -Iinclude \
+  tests/oot3d_pica_pipeline_manifest_tests.cpp \
+  src/fast/oot3d/pica_pipeline_manifest.cpp src/fast/oot3d/pica_aot_shader_pack.cpp \
+  -lgtest -lgtest_main -pthread -o /tmp/manifest_tests && /tmp/manifest_tests
+```
+
+## Verification (2026-09-09, Intel Arc Meteor Lake, Mesa)
+
+Fixed-step replays (`--frames 1500 --fixed-delta-seconds 0.016666`) from an empty
+cache directory:
+
+| Run | prewarm batches | runtime shader compiles | runtime pipeline creations |
+| --- | ---: | ---: | ---: |
+| cold | 0 | 18 misses (16 new modules) | 58 |
+| warm 1-3 | 58 pipelines, 15-26 ms each, before the first guest frame | 0 | 0 |
+
+Strict mode with the baseline pack and a populated local cache aborts on the first
+uncovered shader; with the 322-module candidate corpus it passes 66/66.
+The "Preparing shaders" overlay could not be captured: `--screenshot` reads the
+game framebuffer, not the composited swapchain.

--- a/runtime/three_ds_recomp/include/fast/backends/gfx_rendering_api.h
+++ b/runtime/three_ds_recomp/include/fast/backends/gfx_rendering_api.h
@@ -62,6 +62,14 @@ using GfxNativePicaDisplayImageColorSnapshot =
 using GfxNativePicaPresentationStateSnapshot =
     ::Fast::Renderer3ds::PicaPresentationStateSnapshot;
 
+// Startup shader/pipeline precompilation state. While Blocking, the host must
+// hold the guest and show progress instead of advancing the game.
+struct GfxNativePicaPrewarmProgress {
+    uint32_t Completed = 0;
+    uint32_t Total = 0;
+    bool Blocking = false;
+};
+
 struct GfxNativePicaBackendStats {
     bool Available = false;
     bool GeometryCacheEnabled = false;
@@ -204,6 +212,10 @@ class GfxRenderingAPI : public ::Fast::Renderer3ds::PicaRenderBackend {
         return {};
     }
     virtual void SetNativePicaGeometryCacheEnabled(bool) noexcept {
+    }
+    virtual GfxNativePicaPrewarmProgress NativePicaPipelinePrewarmProgress()
+        const noexcept {
+        return {};
     }
     bool SubmitPicaDraw(const GfxNativePicaDrawView&,
                         std::string* error = nullptr) override {

--- a/runtime/three_ds_recomp/include/fast/backends/gfx_vulkan.h
+++ b/runtime/three_ds_recomp/include/fast/backends/gfx_vulkan.h
@@ -144,6 +144,8 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
     bool SetOot3dPicaAlphaTestShaderParameters(bool enabled, uint32_t function,
                                                uint8_t reference) override;
     bool SupportsOot3dPicaTexture2() const override;
+    GfxNativePicaPrewarmProgress NativePicaPipelinePrewarmProgress()
+        const noexcept override;
     bool PublishPicaCompositionSequence(
         const ::Fast::Renderer3ds::PicaCompositionSequenceView& sequence,
         std::string* error = nullptr) override;
@@ -638,11 +640,26 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
         const std::string& source, bool vertexShader,
         const char* sourceName);
     void ConfigureNativePicaAotShaders();
+    void ConfigureLocalPicaShaderCache();
+    void StoreLocalPicaShaderCache();
     void FinishNativePicaAotShaders();
     void PrewarmNativePicaPipelines();
+    void PrewarmNativePicaPipelineEntry(
+        const Oot3d::PicaGraphicsPipelineManifestEntry& entry);
+    std::span<const uint32_t> FindNativePicaAotSpirv(
+        Oot3d::PicaAotShaderStage stage,
+        const Oot3d::PicaAotShaderSourceIdentity& source) const noexcept;
     std::vector<uint32_t> ResolveNativePicaShaderSpirv(
         std::string_view source, Oot3d::PicaAotShaderStage stage,
         bool vertexShader, const char* sourceName);
+    Oot3d::PicaGraphicsPipelineManifestEntry
+    BuildNativePicaPipelineManifestEntry(
+        const GfxNativePicaDrawView& draw,
+        const NativePicaShaderProgram& shader, bool writesReactiveMask,
+        Oot3d::PicaShaderDomain domain,
+        Oot3d::PicaShaderInstrumentationFeature requestedFeatures,
+        Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
+        bool outlineOcclusionOnly) const;
     VkShaderModule CreateShaderModuleFromSpirv(
         std::span<const uint32_t> spirv);
     VkPipeline GetOrCreateNativePicaPipeline(
@@ -765,10 +782,26 @@ class GfxRenderingAPIVulkan final : public GfxRenderingAPI,
     Oot3d::PicaEffectiveShaderInventory mPicaEffectiveShaderInventory;
     Oot3d::PicaGraphicsPipelineInventory mPicaPipelineInventory;
     Oot3d::PicaGraphicsPipelineManifest mPicaPipelineManifest;
+    // Per-user disk cache: shaders and pipelines discovered at runtime.
+    Oot3d::PicaAotShaderPack mLocalPicaShaderPack;
+    Oot3d::PicaGraphicsPipelineManifest mLocalPicaPipelineManifest;
+    Oot3d::PicaGraphicsPipelineInventory mLocalPicaPipelineInventory;
+    std::vector<Oot3d::PicaAotShaderBinary> mLocalPicaShaderAdditions;
+    std::set<std::pair<Oot3d::PicaAotShaderStage,
+                       Oot3d::PicaAotShaderSourceIdentity>>
+        mLocalPicaShaderAdditionKeys;
+    uint64_t mLocalPicaPipelinesAdded = 0U;
+    uint32_t mLocalPicaDescriptorSchema = 0U;
+    bool mLocalPicaCacheEnabled = false;
+    std::vector<const Oot3d::PicaGraphicsPipelineManifestEntry*>
+        mPicaPipelinePrewarmQueue;
+    size_t mPicaPipelinePrewarmCursor = 0U;
+    std::chrono::steady_clock::time_point mPicaPipelinePrewarmBatchStart{};
     std::set<uint64_t> mPicaPipelinePrewarmedProfiles;
     std::set<std::pair<Oot3d::PicaAotShaderStage, uint64_t>>
         mPicaAotShaderMissesLogged;
     uint64_t mPicaAotShaderHits = 0;
+    uint64_t mLocalPicaShaderHits = 0;
     uint64_t mPicaAotShaderMisses = 0;
     bool mPicaAotShaderStrict = false;
     bool mPicaAotShaderSummaryLogged = false;

--- a/runtime/three_ds_recomp/include/fast/oot3d/graphics_settings_runtime.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/graphics_settings_runtime.h
@@ -49,7 +49,10 @@ class GraphicsSettingsRuntime final {
     bool RetrySave();
     bool AcknowledgePresentationApplied(
         const GraphicsSettings& applied);
-    bool RejectPresentationApply(const GraphicsSettings& rejected);
+    bool RejectPresentationApply(const GraphicsSettings& rejected,
+                                 std::string reason = {});
+    // Why the last display change was rolled back; empty once a later change applies.
+    [[nodiscard]] std::string LastPresentationRejection() const;
     bool ConfirmPresentation();
     bool RollbackPresentation();
     bool TickPresentation();
@@ -68,5 +71,6 @@ class GraphicsSettingsRuntime final {
     bool mNativePresentationOverride = false;
     bool mPersistenceSuppressed = false;
     GraphicsSettingsSaveState mSaveState = GraphicsSettingsSaveState::Saved;
+    std::string mLastPresentationRejection;
 };
 } // namespace Fast::Oot3d

--- a/runtime/three_ds_recomp/include/fast/oot3d/pica_aot_shader_pack.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/pica_aot_shader_pack.h
@@ -64,6 +64,8 @@ class PicaAotShaderPack final {
     [[nodiscard]] bool Loaded() const noexcept;
     [[nodiscard]] uint32_t DescriptorSchemaVersion() const noexcept;
     [[nodiscard]] size_t EntryCount() const noexcept;
+    // Copies every module; for merging into a rewritten pack at shutdown.
+    [[nodiscard]] std::vector<PicaAotShaderBinary> Binaries() const;
     [[nodiscard]] const std::filesystem::path& Path() const noexcept;
 
   private:

--- a/runtime/three_ds_recomp/include/fast/oot3d/pica_pipeline_manifest.h
+++ b/runtime/three_ds_recomp/include/fast/oot3d/pica_pipeline_manifest.h
@@ -100,6 +100,8 @@ struct PicaGraphicsPipelineManifestEntry {
     uint8_t AttachmentRequirementsKey = 0U;
     uint8_t SampleCount = 1U;
     bool WritesReactiveMask = false;
+    // Pipeline keyed separately at runtime; absent in older manifests.
+    bool OutlineOcclusionOnly = false;
     ::Oot3d::Renderer::PicaTopology Topology =
         ::Oot3d::Renderer::PicaTopology::TriangleList;
     ::Oot3d::Renderer::NativeCullMode CullMode =

--- a/runtime/three_ds_recomp/src/fast/Fast3dGui.cpp
+++ b/runtime/three_ds_recomp/src/fast/Fast3dGui.cpp
@@ -331,6 +331,34 @@ void Fast3dGui::DrawMenu() {
                 mouse->UpdateMouseCapture();
             }
         }
+        if (const auto* api = window != nullptr
+                                  ? window->GetCurrentRenderingAPI()
+                                  : nullptr;
+            api != nullptr) {
+            const auto prewarm = api->NativePicaPipelinePrewarmProgress();
+            if (prewarm.Blocking) {
+                const ImGuiViewport* viewport = ImGui::GetMainViewport();
+                ImGui::SetNextWindowPos(
+                    {viewport->WorkPos.x + viewport->WorkSize.x * 0.5F,
+                     viewport->WorkPos.y + viewport->WorkSize.y * 0.5F},
+                    ImGuiCond_Always, {0.5F, 0.5F});
+                ImGui::SetNextWindowBgAlpha(0.85F);
+                ImGui::Begin("Preparing shaders", nullptr,
+                             ImGuiWindowFlags_NoDecoration |
+                                 ImGuiWindowFlags_NoInputs |
+                                 ImGuiWindowFlags_AlwaysAutoResize |
+                                 ImGuiWindowFlags_NoSavedSettings);
+                ImGui::Text("Preparing shaders  %u / %u", prewarm.Completed,
+                            prewarm.Total);
+                ImGui::ProgressBar(
+                    prewarm.Total == 0U
+                        ? 0.0F
+                        : static_cast<float>(prewarm.Completed) /
+                              static_cast<float>(prewarm.Total),
+                    {320.0F, 0.0F}, "");
+                ImGui::End();
+            }
+        }
     }
 #endif
 }

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
@@ -1735,7 +1735,7 @@ void GfxRenderingAPIVulkan::StartFrame() {
             if (presentationRequest->Kind ==
                 Oot3d::RendererPresentationRequestKind::Candidate) {
                 settingsRuntime.RejectPresentationApply(
-                    initialGraphicsSettings);
+                    initialGraphicsSettings, presentationError);
             }
             SPDLOG_ERROR("OOT3D display settings were not applied: {}",
                          presentationError);

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan.cpp
@@ -45,6 +45,9 @@ constexpr uint32_t kVulkanShaderCacheVersion = 1;
 constexpr uint32_t kVulkanPipelineCacheVersion = 1;
 constexpr uint32_t kSpirvMagic = 0x07230203U;
 constexpr uint64_t kMaximumPipelineCacheBytes = 64ULL * 1024ULL * 1024ULL;
+constexpr const char* kLocalPicaShaderPackName = "local_pica_shaders.o3ps";
+constexpr const char* kLocalPicaPipelineManifestName =
+    "local_pica_pipelines.json";
 
 void* ResolveNriNativeWindow(GfxWindowBackendSDL2* backend) {
 #ifdef _WIN32
@@ -1313,6 +1316,11 @@ void GfxRenderingAPIVulkan::Shutdown() {
         WaitForAllPresents();
         StopPresentWorker();
         vkDeviceWaitIdle(mDevice);
+        // A frame that failed mid-record (strict shader miss) never submits;
+        // ending its pass on a torn-down scope crashes the driver. Freeing the
+        // pool below is valid for a command buffer in the recording state.
+        mNativePicaRenderPassActive = false;
+        mActiveNativePicaRenderTarget = nullptr;
         ShutdownImGuiBackend();
         mSceneSurfaces.Clear();
         mResourceStates.Clear();
@@ -3728,6 +3736,7 @@ void GfxRenderingAPIVulkan::ConfigureNativePicaAotShaders() {
     mPicaPipelinePrewarmedProfiles.clear();
     mPicaAotShaderMissesLogged.clear();
     mPicaAotShaderHits = 0;
+    mLocalPicaShaderHits = 0;
     mPicaAotShaderMisses = 0;
     mPicaAotShaderSummaryLogged = false;
     mPicaPipelinePrewarmSummaryLogged = false;
@@ -3811,9 +3820,132 @@ void GfxRenderingAPIVulkan::ConfigureNativePicaAotShaders() {
             "OOT3D_PICA_PIPELINE_PREWARM requires both a pipeline manifest "
             "and an AOT shader pack");
     }
+    ConfigureLocalPicaShaderCache();
+}
+
+// Per-user disk shader cache, modelled on Citra's: every shader compiled at
+// runtime and every pipeline created at runtime is persisted at shutdown, and
+// the next launch prewarms all of it before the guest runs. SPIR-V and the
+// pipeline descriptors are hardware-independent; the driver's own cache holds
+// the per-GPU binaries.
+void GfxRenderingAPIVulkan::ConfigureLocalPicaShaderCache() {
+    mLocalPicaShaderPack.Clear();
+    mLocalPicaPipelineManifest.Clear();
+    mLocalPicaPipelineInventory.Clear();
+    mLocalPicaShaderAdditions.clear();
+    mLocalPicaShaderAdditionKeys.clear();
+    mLocalPicaPipelinesAdded = 0U;
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
+    const char* disabled = std::getenv("OOT3D_PICA_LOCAL_SHADER_CACHE");
+    // Strict validation answers "does the selected pack cover this content";
+    // the per-user cache would answer it falsely.
+    mLocalPicaCacheEnabled =
+        !mPicaAotShaderStrict &&
+        !(disabled != nullptr && std::string_view(disabled) == "0") &&
+        !VulkanShaderCacheDirectory().empty();
+    if (!mLocalPicaCacheEnabled) {
+        return;
+    }
+    const auto directory = VulkanShaderCacheDirectory();
+    std::string error;
+    if (!mLocalPicaPipelineInventory.Configure(
+            directory / kLocalPicaPipelineManifestName, &error)) {
+        SPDLOG_WARN("Local PICA pipeline cache disabled: {}", error);
+        mLocalPicaCacheEnabled = false;
+        return;
+    }
+    std::error_code ignored;
+    const auto packPath = directory / kLocalPicaShaderPackName;
+    if (std::filesystem::exists(packPath, ignored) &&
+        !mLocalPicaShaderPack.Load(packPath, &error)) {
+        SPDLOG_WARN("Local PICA shader pack ignored: {}", error);
+        mLocalPicaShaderPack.Clear();
+    }
+    if (mLocalPicaShaderPack.Loaded() && mPicaAotShaderPack.Loaded() &&
+        mLocalPicaShaderPack.DescriptorSchemaVersion() !=
+            mPicaAotShaderPack.DescriptorSchemaVersion()) {
+        SPDLOG_WARN("Local PICA shader pack ignored: descriptor schema {} "
+                    "differs from shipped pack schema {}",
+                    mLocalPicaShaderPack.DescriptorSchemaVersion(),
+                    mPicaAotShaderPack.DescriptorSchemaVersion());
+        mLocalPicaShaderPack.Clear();
+    }
+    const auto manifestPath = mLocalPicaPipelineInventory.Path();
+    if (std::filesystem::exists(manifestPath, ignored) &&
+        !mLocalPicaPipelineManifest.Load(manifestPath, &error)) {
+        SPDLOG_WARN("Local PICA pipeline manifest ignored: {}", error);
+        mLocalPicaPipelineManifest.Clear();
+    }
+    if (mLocalPicaPipelineManifest.Loaded() &&
+        mLocalPicaPipelineManifest.DescriptorSchemaVersion() !=
+            (mPicaAotShaderPack.Loaded()
+                 ? mPicaAotShaderPack.DescriptorSchemaVersion()
+                 : mLocalPicaShaderPack.DescriptorSchemaVersion())) {
+        SPDLOG_WARN("Local PICA pipeline manifest ignored: descriptor "
+                    "schema mismatch");
+        mLocalPicaPipelineManifest.Clear();
+    }
+    // Seed the inventory so the rewritten manifest is the union.
+    for (const auto& entry : mLocalPicaPipelineManifest.Entries()) {
+        mLocalPicaPipelineInventory.Observe(entry, 0U, 0U);
+    }
+    std::fprintf(stderr,
+                 "OOT3D_PICA_LOCAL_SHADER_CACHE modules=%zu pipelines=%zu "
+                 "path=%s\n",
+                 mLocalPicaShaderPack.EntryCount(),
+                 mLocalPicaPipelineManifest.Entries().size(),
+                 directory.string().c_str());
+}
+
+void GfxRenderingAPIVulkan::StoreLocalPicaShaderCache() {
+    if (!mLocalPicaCacheEnabled) {
+        return;
+    }
+    std::string error;
+    std::fprintf(stderr,
+                 "OOT3D_PICA_LOCAL_SHADER_CACHE session added_modules=%zu "
+                 "added_pipelines=%llu\n",
+                 mLocalPicaShaderAdditions.size(),
+                 static_cast<unsigned long long>(mLocalPicaPipelinesAdded));
+    if (!mLocalPicaShaderAdditions.empty()) {
+        auto binaries = mLocalPicaShaderPack.Binaries();
+        binaries.insert(binaries.end(), mLocalPicaShaderAdditions.begin(),
+                        mLocalPicaShaderAdditions.end());
+        const uint32_t schema = mPicaAotShaderPack.Loaded()
+            ? mPicaAotShaderPack.DescriptorSchemaVersion()
+            : mLocalPicaShaderPack.Loaded()
+                  ? mLocalPicaShaderPack.DescriptorSchemaVersion()
+                  : mLocalPicaDescriptorSchema;
+        const auto path =
+            VulkanShaderCacheDirectory() / kLocalPicaShaderPackName;
+        if (schema == 0U) {
+            SPDLOG_WARN("Local PICA shader pack not written: no descriptor "
+                        "schema observed");
+        } else if (!Oot3d::WritePicaAotShaderPack(path, schema, binaries,
+                                                  &error)) {
+            SPDLOG_WARN("Local PICA shader pack not written: {}", error);
+        } else {
+            std::fprintf(stderr,
+                         "OOT3D_PICA_LOCAL_SHADER_CACHE wrote modules=%zu\n",
+                         binaries.size());
+            mLocalPicaShaderAdditions.clear();
+        }
+    }
+    if (mLocalPicaPipelinesAdded != 0U) {
+        if (!mLocalPicaPipelineInventory.Finish(&error)) {
+            SPDLOG_WARN("Local PICA pipeline manifest not written: {}", error);
+        } else {
+            std::fprintf(stderr,
+                         "OOT3D_PICA_LOCAL_SHADER_CACHE wrote pipelines=%zu\n",
+                         mLocalPicaPipelineInventory.EntryCount());
+            mLocalPicaPipelinesAdded = 0U;
+        }
+    }
 }
 
 void GfxRenderingAPIVulkan::FinishNativePicaAotShaders() {
+    StoreLocalPicaShaderCache();
     if (mPicaEffectiveShaderInventory.Enabled()) {
         std::string error;
         if (!mPicaEffectiveShaderInventory.Finish(&error)) {
@@ -3866,13 +3998,16 @@ void GfxRenderingAPIVulkan::FinishNativePicaAotShaders() {
     }
     if (!mPicaAotShaderSummaryLogged &&
         (mPicaAotShaderPack.Loaded() || mPicaAotShaderHits != 0U ||
-         mPicaAotShaderMisses != 0U)) {
-        SPDLOG_INFO("Native PICA AOT shader resolution: {} hits, {} misses",
-                    mPicaAotShaderHits, mPicaAotShaderMisses);
+         mLocalPicaShaderHits != 0U || mPicaAotShaderMisses != 0U)) {
+        SPDLOG_INFO("Native PICA AOT shader resolution: {} shipped hits, "
+                    "{} local hits, {} misses",
+                    mPicaAotShaderHits, mLocalPicaShaderHits,
+                    mPicaAotShaderMisses);
         std::fprintf(stderr,
-                     "OOT3D_PICA_AOT_SHADER_RESOLUTION hits=%llu misses=%llu "
-                     "strict=%u entries=%zu\n",
+                     "OOT3D_PICA_AOT_SHADER_RESOLUTION hits=%llu "
+                     "local_hits=%llu misses=%llu strict=%u entries=%zu\n",
                      static_cast<unsigned long long>(mPicaAotShaderHits),
+                     static_cast<unsigned long long>(mLocalPicaShaderHits),
                      static_cast<unsigned long long>(mPicaAotShaderMisses),
                      mPicaAotShaderStrict ? 1U : 0U,
                      mPicaAotShaderPack.EntryCount());
@@ -3884,18 +4019,28 @@ std::vector<uint32_t>
 GfxRenderingAPIVulkan::ResolveNativePicaShaderSpirv(
     std::string_view source, Oot3d::PicaAotShaderStage stage,
     bool vertexShader, const char* sourceName) {
-    if (!mPicaAotShaderPack.Loaded()) {
+    const bool anyPack =
+        mPicaAotShaderPack.Loaded() || mLocalPicaShaderPack.Loaded();
+    if (!anyPack && !mLocalPicaCacheEnabled) {
         return CompileShaderSpirv(std::string(source), vertexShader,
                                   sourceName);
     }
-    const auto binary = mPicaAotShaderPack.Find(stage, source);
+    const auto identity = Oot3d::IdentifyPicaAotShaderSource(source);
+    // Strict validation must be satisfied only by the explicitly selected pack.
+    const auto binary = mPicaAotShaderStrict
+        ? mPicaAotShaderPack.Find(stage, identity)
+        : FindNativePicaAotSpirv(stage, identity);
     if (!binary.empty()) {
-        ++mPicaAotShaderHits;
+        // "hits" measures shipped-pack coverage; local-cache hits are separate.
+        if (!mPicaAotShaderPack.Find(stage, identity).empty()) {
+            ++mPicaAotShaderHits;
+        } else {
+            ++mLocalPicaShaderHits;
+        }
         return {binary.begin(), binary.end()};
     }
 
     ++mPicaAotShaderMisses;
-    const auto identity = Oot3d::IdentifyPicaAotShaderSource(source);
     if (mPicaAotShaderMissesLogged.insert({stage, identity.Id}).second) {
         SPDLOG_WARN(
             "Native PICA AOT shader miss: stage={}, source={}, name={}",
@@ -3908,8 +4053,13 @@ GfxRenderingAPIVulkan::ResolveNativePicaShaderSpirv(
             std::string(Oot3d::PicaAotShaderStageName(stage)) +
             " module for " + Oot3d::FormatPicaAotShaderId(identity.Id));
     }
-    return CompileShaderSpirv(std::string(source), vertexShader,
-                              sourceName);
+    auto spirv = CompileShaderSpirv(std::string(source), vertexShader,
+                                    sourceName);
+    if (mLocalPicaCacheEnabled &&
+        mLocalPicaShaderAdditionKeys.insert({stage, identity}).second) {
+        mLocalPicaShaderAdditions.push_back({stage, identity, spirv});
+    }
+    return spirv;
 }
 
 VkShaderModule GfxRenderingAPIVulkan::CreateShaderModuleFromSpirv(
@@ -4841,6 +4991,8 @@ void GfxRenderingAPIVulkan::DestroyGraphicsPipelines() {
     }
     mNativePicaPipelines.clear();
     mPicaPipelinePrewarmedProfiles.clear();
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
     if (mNativePicaScanoutPipeline != VK_NULL_HANDLE) {
         vkDestroyPipeline(mDevice, mNativePicaScanoutPipeline, nullptr);
         mNativePicaScanoutPipeline = VK_NULL_HANDLE;

--- a/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan_pica.cpp
+++ b/runtime/three_ds_recomp/src/fast/backends/gfx_vulkan_pica.cpp
@@ -977,6 +977,8 @@ void GfxRenderingAPIVulkan::ApplyNativePicaSampleCount(VkSampleCountFlagBits sam
     }
     mNativePicaPipelines.clear();
     mPicaPipelinePrewarmedProfiles.clear();
+    mPicaPipelinePrewarmQueue.clear();
+    mPicaPipelinePrewarmCursor = 0U;
     if (mNativePicaRenderPass != VK_NULL_HANDLE) {
         vkDestroyRenderPass(mDevice, mNativePicaRenderPass, nullptr);
         mNativePicaRenderPass = VK_NULL_HANDLE;
@@ -3269,6 +3271,78 @@ void GfxRenderingAPIVulkan::CreateNativePicaTextureImage(
     RecreateSampler(texture);
 }
 
+Oot3d::PicaGraphicsPipelineManifestEntry
+GfxRenderingAPIVulkan::BuildNativePicaPipelineManifestEntry(
+    const GfxNativePicaDrawView& draw,
+    const NativePicaShaderProgram& shader, bool writesReactiveMask,
+    Oot3d::PicaShaderDomain domain,
+    Oot3d::PicaShaderInstrumentationFeature requestedFeatures,
+    Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
+    bool outlineOcclusionOnly) const {
+    Oot3d::PicaGraphicsPipelineManifestEntry entry;
+    entry.DescriptorSchemaVersion =
+        draw.CanonicalDescriptorSchemaVersion;
+    entry.Domain = domain == Oot3d::PicaShaderDomain::Canonical
+        ? Oot3d::PicaGraphicsPipelineDomain::Canonical
+        : Oot3d::PicaGraphicsPipelineDomain::Instrumented;
+    entry.VertexShaderKey = draw.VertexShaderKey;
+    entry.FragmentShaderKey = draw.FragmentShaderKey;
+    entry.VertexSource = shader.VertexSource;
+    entry.FragmentSource = shader.FragmentSource;
+    entry.NriFragmentSource = shader.NriFragmentSource;
+    entry.NriFragmentAvailable = shader.NriDescriptorContract;
+    entry.RequestedFeatures = requestedFeatures;
+    entry.AppliedFeatures = appliedFeatures;
+    entry.AttachmentRequirementsKey =
+        mFramePicaAttachmentRequirements.Key();
+    entry.SampleCount =
+        static_cast<uint8_t>(mNativePicaSampleCount);
+    entry.WritesReactiveMask = writesReactiveMask;
+    entry.OutlineOcclusionOnly = outlineOcclusionOnly;
+    entry.Topology = draw.Topology;
+    entry.CullMode = draw.CullMode;
+    entry.FramebufferFlipped = draw.FramebufferFlipped;
+    entry.VertexBindings.reserve(draw.VertexBindings.size());
+    for (const auto& binding : draw.VertexBindings) {
+        entry.VertexBindings.push_back({
+            binding.Binding, binding.ByteStride, binding.PerInstance});
+    }
+    entry.VertexAttributes.reserve(draw.VertexAttributes.size());
+    for (const auto& attribute : draw.VertexAttributes) {
+        entry.VertexAttributes.push_back({
+            attribute.Location, attribute.Binding, attribute.Format,
+            attribute.ComponentCount, attribute.ByteOffset});
+    }
+    entry.ColorWriteMask = draw.ColorWriteMask;
+    entry.FragmentOperationMode = draw.FragmentOperationMode;
+    entry.LogicOperation = draw.LogicOperation;
+    entry.Blend = {
+        draw.Blend.Enabled,
+        draw.Blend.EquationRgb,
+        draw.Blend.EquationAlpha,
+        draw.Blend.SourceRgb,
+        draw.Blend.DestRgb,
+        draw.Blend.SourceAlpha,
+        draw.Blend.DestAlpha,
+    };
+    entry.AlphaTestEnabled = draw.AlphaTestEnabled;
+    entry.DepthTestEnabled = draw.DepthTestEnabled;
+    entry.DepthWriteEnabled = draw.DepthWriteEnabled;
+    entry.DepthCompare = draw.DepthCompare;
+    entry.Stencil = {
+        draw.Stencil.Enabled,
+        draw.Stencil.Compare,
+        draw.Stencil.Reference,
+        draw.Stencil.CompareMask,
+        draw.Stencil.WriteMask,
+        draw.Stencil.Fail,
+        draw.Stencil.DepthFail,
+        draw.Stencil.Pass,
+    };
+    entry.ShaderOutputs = shader.FragmentOutputs;
+    return entry;
+}
+
 VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
     const GfxNativePicaDrawView& draw,
     const NativePicaShaderProgram& shader, bool writesReactiveMask,
@@ -3277,69 +3351,11 @@ VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
     Oot3d::PicaShaderInstrumentationFeature appliedFeatures,
     bool recordInventory, bool outlineOcclusionOnly) {
     if (recordInventory && mPicaPipelineInventory.Enabled()) {
-        Oot3d::PicaGraphicsPipelineManifestEntry entry;
-        entry.DescriptorSchemaVersion =
-            draw.CanonicalDescriptorSchemaVersion;
-        entry.Domain = domain == Oot3d::PicaShaderDomain::Canonical
-            ? Oot3d::PicaGraphicsPipelineDomain::Canonical
-            : Oot3d::PicaGraphicsPipelineDomain::Instrumented;
-        entry.VertexShaderKey = draw.VertexShaderKey;
-        entry.FragmentShaderKey = draw.FragmentShaderKey;
-        entry.VertexSource = shader.VertexSource;
-        entry.FragmentSource = shader.FragmentSource;
-        entry.NriFragmentSource = shader.NriFragmentSource;
-        entry.NriFragmentAvailable = shader.NriDescriptorContract;
-        entry.RequestedFeatures = requestedFeatures;
-        entry.AppliedFeatures = appliedFeatures;
-        entry.AttachmentRequirementsKey =
-            mFramePicaAttachmentRequirements.Key();
-        entry.SampleCount =
-            static_cast<uint8_t>(mNativePicaSampleCount);
-        entry.WritesReactiveMask = writesReactiveMask;
-        entry.Topology = draw.Topology;
-        entry.CullMode = draw.CullMode;
-        entry.FramebufferFlipped = draw.FramebufferFlipped;
-        entry.VertexBindings.reserve(draw.VertexBindings.size());
-        for (const auto& binding : draw.VertexBindings) {
-            entry.VertexBindings.push_back({
-                binding.Binding, binding.ByteStride, binding.PerInstance});
-        }
-        entry.VertexAttributes.reserve(draw.VertexAttributes.size());
-        for (const auto& attribute : draw.VertexAttributes) {
-            entry.VertexAttributes.push_back({
-                attribute.Location, attribute.Binding, attribute.Format,
-                attribute.ComponentCount, attribute.ByteOffset});
-        }
-        entry.ColorWriteMask = draw.ColorWriteMask;
-        entry.FragmentOperationMode = draw.FragmentOperationMode;
-        entry.LogicOperation = draw.LogicOperation;
-        entry.Blend = {
-            draw.Blend.Enabled,
-            draw.Blend.EquationRgb,
-            draw.Blend.EquationAlpha,
-            draw.Blend.SourceRgb,
-            draw.Blend.DestRgb,
-            draw.Blend.SourceAlpha,
-            draw.Blend.DestAlpha,
-        };
-        entry.AlphaTestEnabled = draw.AlphaTestEnabled;
-        entry.DepthTestEnabled = draw.DepthTestEnabled;
-        entry.DepthWriteEnabled = draw.DepthWriteEnabled;
-        entry.DepthCompare = draw.DepthCompare;
-        entry.Stencil = {
-            draw.Stencil.Enabled,
-            draw.Stencil.Compare,
-            draw.Stencil.Reference,
-            draw.Stencil.CompareMask,
-            draw.Stencil.WriteMask,
-            draw.Stencil.Fail,
-            draw.Stencil.DepthFail,
-            draw.Stencil.Pass,
-        };
-        entry.ShaderOutputs = shader.FragmentOutputs;
         mPicaPipelineInventory.Observe(
-            std::move(entry), draw.CanonicalPipelineId,
-            mFrameGraphicsSettingsRevision);
+            BuildNativePicaPipelineManifestEntry(
+                draw, shader, writesReactiveMask, domain,
+                requestedFeatures, appliedFeatures, outlineOcclusionOnly),
+            draw.CanonicalPipelineId, mFrameGraphicsSettingsRevision);
     }
     std::vector<uint8_t> key;
     AppendKey(key, static_cast<uint8_t>(outlineOcclusionOnly));
@@ -3707,15 +3723,46 @@ VkPipeline GfxRenderingAPIVulkan::GetOrCreateNativePicaPipeline(
         }
     }
     mNativePicaPipelines.emplace(std::move(key), pipeline);
+    // Only newly created pipelines enter the per-user cache: the next launch
+    // prewarms them before the guest runs.
+    if (recordInventory && mLocalPicaPipelineInventory.Enabled()) {
+        if (mLocalPicaDescriptorSchema == 0U) {
+            mLocalPicaDescriptorSchema = draw.CanonicalDescriptorSchemaVersion;
+        }
+        mLocalPicaPipelineInventory.Observe(
+            BuildNativePicaPipelineManifestEntry(
+                draw, shader, writesReactiveMask, domain,
+                requestedFeatures, appliedFeatures, outlineOcclusionOnly),
+            draw.CanonicalPipelineId, mFrameGraphicsSettingsRevision);
+        ++mLocalPicaPipelinesAdded;
+    }
     return pipeline;
 }
 
+std::span<const uint32_t> GfxRenderingAPIVulkan::FindNativePicaAotSpirv(
+    Oot3d::PicaAotShaderStage stage,
+    const Oot3d::PicaAotShaderSourceIdentity& source) const noexcept {
+    const auto shipped = mPicaAotShaderPack.Find(stage, source);
+    return shipped.empty() ? mLocalPicaShaderPack.Find(stage, source)
+                           : shipped;
+}
+
+GfxNativePicaPrewarmProgress
+GfxRenderingAPIVulkan::NativePicaPipelinePrewarmProgress() const noexcept {
+    // Until StartFrame has evaluated the current profile no queue exists;
+    // hold the guest so its draws cannot race the batch. Every batch holds:
+    // a pipeline created on a draw is exactly the hitch this removes.
+    return {static_cast<uint32_t>(mPicaPipelinePrewarmCursor),
+            static_cast<uint32_t>(mPicaPipelinePrewarmQueue.size()),
+            mPicaPipelinePrewarmedProfiles.empty() ||
+                mPicaPipelinePrewarmCursor < mPicaPipelinePrewarmQueue.size()};
+}
+
 void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
-    if (!mPicaPipelinePrewarmEnabled ||
-        !mPicaPipelineManifest.Loaded() ||
-        !mPicaAotShaderPack.Loaded()) {
-        return;
-    }
+    const bool shipped = mPicaPipelinePrewarmEnabled &&
+                         mPicaPipelineManifest.Loaded() &&
+                         mPicaAotShaderPack.Loaded();
+    const bool local = mLocalPicaPipelineManifest.Loaded();
     const uint8_t sampleCount =
         static_cast<uint8_t>(mNativePicaSampleCount);
     const auto activeFeatures = Oot3d::ResolvePicaShaderProfileFeatures(
@@ -3728,22 +3775,72 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
         (static_cast<uint64_t>(sampleCount) << 8U) |
         (static_cast<uint64_t>(activeFeatures) << 16U) |
         (mNativeFidelityProfile ? 1ULL << 48U : 0U);
-    if (!mPicaPipelinePrewarmedProfiles.insert(profile).second) {
+    if (mPicaPipelinePrewarmedProfiles.insert(profile).second &&
+        (shipped || local)) {
+        const uint32_t schema = mPicaAotShaderPack.Loaded()
+            ? mPicaAotShaderPack.DescriptorSchemaVersion()
+            : mLocalPicaShaderPack.DescriptorSchemaVersion();
+        const auto enqueue = [&](const Oot3d::PicaGraphicsPipelineManifest&
+                                     manifest) {
+            for (const auto& entry : manifest.Entries()) {
+                if (entry.AttachmentRequirementsKey ==
+                        mFramePicaAttachmentRequirements.Key() &&
+                    entry.SampleCount == sampleCount &&
+                    entry.DescriptorSchemaVersion == schema &&
+                    entry.MatchesPrewarmProfile(activeFeatures,
+                                                mNativeFidelityProfile)) {
+                    mPicaPipelinePrewarmQueue.push_back(&entry);
+                }
+            }
+        };
+        // Manifest entry storage is stable until Clear(); pointers are safe.
+        if (shipped) enqueue(mPicaPipelineManifest);
+        if (local) enqueue(mLocalPicaPipelineManifest);
+        if (mPicaPipelinePrewarmCursor == 0U) {
+            mPicaPipelinePrewarmBatchStart = std::chrono::steady_clock::now();
+        }
+    }
+    if (mPicaPipelinePrewarmCursor >= mPicaPipelinePrewarmQueue.size()) {
         return;
     }
+    // The guest is held meanwhile; the budget only bounds overlay latency.
+    static const uint32_t budgetMs = [] {
+        const char* value =
+            std::getenv("OOT3D_PICA_PIPELINE_PREWARM_BUDGET_MS");
+        return value != nullptr ? static_cast<uint32_t>(std::atoi(value))
+                                : 50U;
+    }();
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(budgetMs);
+    while (mPicaPipelinePrewarmCursor < mPicaPipelinePrewarmQueue.size() &&
+           std::chrono::steady_clock::now() < deadline) {
+        PrewarmNativePicaPipelineEntry(
+            *mPicaPipelinePrewarmQueue[mPicaPipelinePrewarmCursor++]);
+    }
+    if (mPicaPipelinePrewarmCursor >= mPicaPipelinePrewarmQueue.size()) {
+        std::fprintf(
+            stderr,
+            "OOT3D_PICA_PIPELINE_PREWARM_BATCH pipelines=%zu ms=%lld "
+            "created=%llu reused=%llu skipped=%llu\n",
+            mPicaPipelinePrewarmQueue.size(),
+            static_cast<long long>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() -
+                    mPicaPipelinePrewarmBatchStart)
+                    .count()),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmCreated),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmReused),
+            static_cast<unsigned long long>(mPicaPipelinePrewarmSkipped));
+        mPicaPipelinePrewarmQueue.clear();
+        mPicaPipelinePrewarmCursor = 0U;
+    }
+}
 
+void GfxRenderingAPIVulkan::PrewarmNativePicaPipelineEntry(
+    const Oot3d::PicaGraphicsPipelineManifestEntry& entry) {
     const std::array<uint8_t, 1> dummyVertexBytes{};
-    for (const auto& entry : mPicaPipelineManifest.Entries()) {
-        if (entry.AttachmentRequirementsKey !=
-                mFramePicaAttachmentRequirements.Key() ||
-            entry.SampleCount != sampleCount ||
-            entry.DescriptorSchemaVersion !=
-                mPicaAotShaderPack.DescriptorSchemaVersion() ||
-            !entry.MatchesPrewarmProfile(
-                activeFeatures, mNativeFidelityProfile)) {
-            continue;
-        }
-
+    {
+        // Profile, sample count and schema were matched when enqueued.
         auto& shaderCache =
             entry.Domain == Oot3d::PicaGraphicsPipelineDomain::Canonical
                 ? mCanonicalNativePicaShaders
@@ -3753,7 +3850,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
         if (mNriPicaPipelineBridge.Available() &&
             !entry.NriFragmentAvailable) {
             ++mPicaPipelinePrewarmSkipped;
-            continue;
+            return;
         }
         auto shaderIt = shaderCache.find(shaderKey);
         if (shaderIt != shaderCache.end() &&
@@ -3767,27 +3864,27 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                   entry.NriFragmentSource) ||
              shaderIt->second.FragmentOutputs != entry.ShaderOutputs)) {
             ++mPicaPipelinePrewarmSkipped;
-            continue;
+            return;
         }
         if (shaderIt == shaderCache.end()) {
-            const auto vertexSpirv = mPicaAotShaderPack.Find(
+            const auto vertexSpirv = FindNativePicaAotSpirv(
                 Oot3d::PicaAotShaderStage::Vertex, entry.VertexSource);
-            const auto fragmentSpirv = mPicaAotShaderPack.Find(
+            const auto fragmentSpirv = FindNativePicaAotSpirv(
                 Oot3d::PicaAotShaderStage::Fragment,
                 entry.FragmentSource);
             if (vertexSpirv.empty() || fragmentSpirv.empty()) {
                 ++mPicaPipelinePrewarmSkipped;
-                continue;
+                return;
             }
             std::span<const uint32_t> nriFragmentSpirv;
             if (entry.NriFragmentAvailable &&
                 mNriPicaPipelineBridge.Available()) {
-                nriFragmentSpirv = mPicaAotShaderPack.Find(
+                nriFragmentSpirv = FindNativePicaAotSpirv(
                     Oot3d::PicaAotShaderStage::NriFragment,
                     entry.NriFragmentSource);
                 if (nriFragmentSpirv.empty()) {
                     ++mPicaPipelinePrewarmSkipped;
-                    continue;
+                    return;
                 }
             }
 
@@ -3823,7 +3920,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                 SPDLOG_WARN(
                     "Native PICA pipeline prewarm shader creation failed: {}",
                     exception.what());
-                continue;
+                return;
             }
         }
 
@@ -3887,7 +3984,7 @@ void GfxRenderingAPIVulkan::PrewarmNativePicaPipelines() {
                     ? Oot3d::PicaShaderDomain::Canonical
                     : Oot3d::PicaShaderDomain::Instrumented,
                 entry.RequestedFeatures, entry.AppliedFeatures,
-                false);
+                false, entry.OutlineOcclusionOnly);
             if (mNativePicaPipelines.size() == pipelineCount) {
                 ++mPicaPipelinePrewarmReused;
             } else {
@@ -5418,7 +5515,7 @@ bool GfxRenderingAPIVulkan::SubmitPicaDraw(
             ? GetOrCreateNativePicaPipeline(
                 effectiveDraw, shaderIt->second, shaderVariant.Reactive,
                 shaderVariant.Domain, shaderVariant.RequestedFeatures, shaderVariant.AppliedFeatures,
-                false, true)
+                true, true)
             : VK_NULL_HANDLE;
         // Coverage runs before the native draw: stencil must still have its
         // original value if that draw modifies it. The auxiliary pass is read-only.

--- a/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_runtime.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_runtime.cpp
@@ -462,6 +462,10 @@ bool GraphicsSettingsRuntime::RetrySave() {
     std::scoped_lock lock(mMutex);
     return PersistCurrentLocked();
 }
+std::string GraphicsSettingsRuntime::LastPresentationRejection() const {
+    std::scoped_lock lock(mMutex);
+    return mLastPresentationRejection;
+}
 bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     const GraphicsSettings& applied) {
     std::scoped_lock lock(mMutex);
@@ -470,6 +474,9 @@ bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     const bool acknowledged = mPresentationTransaction.MarkApplied(
         GetPresentationSettings(applied),
         PresentationClockMilliseconds());
+    if (acknowledged) {
+        mLastPresentationRejection.clear();
+    }
     if (acknowledged &&
         (phase == PresentationTransactionPhase::RollbackRequested ||
          mPresentationTransaction.Status(PresentationClockMilliseconds())
@@ -479,8 +486,9 @@ bool GraphicsSettingsRuntime::AcknowledgePresentationApplied(
     return acknowledged;
 }
 bool GraphicsSettingsRuntime::RejectPresentationApply(
-    const GraphicsSettings& rejected) {
+    const GraphicsSettings& rejected, std::string reason) {
     std::scoped_lock lock(mMutex);
+    mLastPresentationRejection = std::move(reason);
     const auto status = mPresentationTransaction.Status(
         PresentationClockMilliseconds());
     if (GetPresentationSettings(rejected) !=

--- a/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_window.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/graphics_settings_window.cpp
@@ -52,6 +52,10 @@ void GraphicsSettingsPanel::DrawPresentationStatus() {
     } else if (status.Phase == PresentationTransactionPhase::RollbackRequested) {
         ImGui::TextUnformatted("Restoring previous display settings...");
     }
+    if (const auto rejection = runtime.LastPresentationRejection();
+        !rejection.empty()) {
+        ImGui::TextWrapped("Display change reverted: %s", rejection.c_str());
+    }
     switch (runtime.SaveState()) {
         case GraphicsSettingsSaveState::Failed:
             ImGui::TextWrapped("Settings applied, but could not be saved.");

--- a/runtime/three_ds_recomp/src/fast/oot3d/pica_aot_shader_pack.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/pica_aot_shader_pack.cpp
@@ -386,6 +386,19 @@ size_t PicaAotShaderPack::EntryCount() const noexcept {
     return mEntries.size();
 }
 
+std::vector<PicaAotShaderBinary> PicaAotShaderPack::Binaries() const {
+    std::vector<PicaAotShaderBinary> result;
+    result.reserve(mEntries.size());
+    for (const auto& [key, range] : mEntries) {
+        const auto spirv = Find(key.Stage, key.Source);
+        if (!spirv.empty()) {
+            result.push_back({key.Stage, key.Source,
+                              {spirv.begin(), spirv.end()}});
+        }
+    }
+    return result;
+}
+
 const std::filesystem::path& PicaAotShaderPack::Path() const noexcept {
     return mPath;
 }

--- a/runtime/three_ds_recomp/src/fast/oot3d/pica_pipeline_manifest.cpp
+++ b/runtime/three_ds_recomp/src/fast/oot3d/pica_pipeline_manifest.cpp
@@ -206,6 +206,7 @@ nlohmann::json EntryJson(
         {"attachment_requirements_key", entry.AttachmentRequirementsKey},
         {"sample_count", entry.SampleCount},
         {"writes_reactive_mask", entry.WritesReactiveMask},
+        {"outline_occlusion_only", entry.OutlineOcclusionOnly},
         {"topology", static_cast<uint8_t>(entry.Topology)},
         {"cull_mode", static_cast<uint8_t>(entry.CullMode)},
         {"framebuffer_flipped", entry.FramebufferFlipped},
@@ -329,6 +330,9 @@ bool ReadEntry(const nlohmann::json& value,
         !ReadUnsigned(value, "sample_count", entry.SampleCount) ||
         !ReadBool(value, "writes_reactive_mask",
                   entry.WritesReactiveMask) ||
+        (value.contains("outline_occlusion_only") &&
+         !ReadBool(value, "outline_occlusion_only",
+                   entry.OutlineOcclusionOnly)) ||
         !value.contains("topology") ||
         !ReadEnum(value["topology"],
                   ::Oot3d::Renderer::PicaTopology::GeometryShader,
@@ -649,6 +653,10 @@ uint64_t PicaGraphicsPipelineManifestEntry::StructuralId() const noexcept {
     HashValue(hash, AttachmentRequirementsKey);
     HashValue(hash, SampleCount);
     HashValue(hash, WritesReactiveMask);
+    // Only hashed when set so ids of pre-existing entries stay valid.
+    if (OutlineOcclusionOnly) {
+        HashValue(hash, OutlineOcclusionOnly);
+    }
     HashValue(hash, Topology);
     HashValue(hash, CullMode);
     HashValue(hash, FramebufferFlipped);
@@ -716,6 +724,7 @@ bool PicaGraphicsPipelineManifestEntry::StructurallyEquivalent(
            AttachmentRequirementsKey == other.AttachmentRequirementsKey &&
            SampleCount == other.SampleCount &&
            WritesReactiveMask == other.WritesReactiveMask &&
+           OutlineOcclusionOnly == other.OutlineOcclusionOnly &&
            Topology == other.Topology && CullMode == other.CullMode &&
            FramebufferFlipped == other.FramebufferFlipped &&
            VertexBindings == other.VertexBindings &&

--- a/runtime/three_ds_recomp/tests/oot3d_pica_pipeline_manifest_tests.cpp
+++ b/runtime/three_ds_recomp/tests/oot3d_pica_pipeline_manifest_tests.cpp
@@ -2,8 +2,12 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
 
 namespace Fast::Oot3d {
 namespace {
@@ -106,6 +110,51 @@ TEST(PicaPipelineManifest, RoundTripsTypedPipelineState) {
     EXPECT_EQ(loaded.ObservationCount, 8U);
     EXPECT_EQ(loaded.CanonicalPipelineIds, entry.CanonicalPipelineIds);
     EXPECT_EQ(loaded.SettingsRevisions, entry.SettingsRevisions);
+
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+}
+
+TEST(PicaPipelineManifest, OutlineOcclusionFlagIsCompatibleWithOlderManifests) {
+    const auto path = TemporaryPath("oot3d_pica_pipeline_outline");
+    auto plain = MakeEntry();
+    auto outline = MakeEntry();
+    outline.OutlineOcclusionOnly = true;
+    EXPECT_NE(plain.StructuralId(), outline.StructuralId());
+    EXPECT_FALSE(plain.StructurallyEquivalent(outline));
+
+    const std::array entries{plain, outline};
+    std::string error;
+    ASSERT_TRUE(WritePicaGraphicsPipelineManifest(
+        path, plain.DescriptorSchemaVersion, entries, &error)) << error;
+
+    // Manifests written before the flag existed carry neither the key nor its
+    // hash contribution; drop every "false" line and the stored ids must still
+    // validate, while the "true" entry keeps its flag and distinct id.
+    std::ifstream input(path);
+    std::stringstream kept;
+    size_t trueLines = 0U;
+    for (std::string line; std::getline(input, line);) {
+        if (line.find("\"outline_occlusion_only\": false") != std::string::npos) {
+            continue;
+        }
+        trueLines += line.find("\"outline_occlusion_only\": true") != std::string::npos;
+        kept << line << '\n';
+    }
+    input.close();
+    ASSERT_EQ(trueLines, 1U);
+    std::ofstream(path, std::ios::trunc) << kept.str();
+
+    PicaGraphicsPipelineManifest manifest;
+    ASSERT_TRUE(manifest.Load(path, &error)) << error;
+    ASSERT_EQ(manifest.Entries().size(), 2U);
+    size_t outlineEntries = 0U;
+    for (const auto& loaded : manifest.Entries()) {
+        outlineEntries += loaded.OutlineOcclusionOnly ? 1U : 0U;
+        EXPECT_TRUE(loaded.StructurallyEquivalent(
+            loaded.OutlineOcclusionOnly ? outline : plain));
+    }
+    EXPECT_EQ(outlineEntries, 1U);
 
     std::error_code ignored;
     std::filesystem::remove(path, ignored);

--- a/scripts/extend-pica-corpus.sh
+++ b/scripts/extend-pica-corpus.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fold a recorded play session (run-linux-title.sh with TRIAEVUM_SHADER_INVENTORY=1,
+# window closed normally) into a candidate AOT shader pack and prewarm manifest
+# under RUNTIME_BUILD/pica-corpus. The checked-in baseline is read, never written.
+# Cumulative: the candidate inventory and manifest grow with every session.
+#
+# Validate before promoting: launch with TRIAEVUM_PICA_CORPUS=1 and
+# TRIAEVUM_PICA_STRICT=1 and replay the recorded areas; any miss aborts the run.
+# Promote by copying pica-corpus/shader-inventory.json over
+# tools/oot3d/native_pica_frontend/profiles/oot3d_pica_boot_title_kokiri_pipeline.json
+# once the strict replay and a framebuffer comparison against dynamic generation
+# pass (docs/OOT3D_NRI_PICA_AOT_RENDERER_PARITY.md, "Extending coverage").
+if [[ $# -ne 2 ]]; then
+  printf 'Usage: bash %s INSTALLATION RUNTIME_BUILD\n' "$0" >&2
+  exit 2
+fi
+installation="$(realpath "$1")"
+runtime="$(realpath "$2")"
+root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+captures="$installation/linux-captures"
+baseline="$root/tools/oot3d/native_pica_frontend/profiles/oot3d_pica_boot_title_kokiri_pipeline.json"
+corpus="$runtime/pica-corpus"
+archive="$corpus/sessions/$(date +%Y%m%d-%H%M%S)"
+
+test -x "$runtime/oot3d_native_pica_aot_compiler"
+test -x "$runtime/oot3d_native_pica_pipeline_manifest"
+test -f "$captures/shader-inventory.json"
+mkdir -p "$archive"
+
+inventories=(--inventory "$baseline")
+[[ -f "$corpus/shader-inventory.json" ]] && inventories+=(--inventory "$corpus/shader-inventory.json")
+"$runtime/oot3d_native_pica_aot_compiler" \
+  "${inventories[@]}" --inventory "$captures/shader-inventory.json" \
+  --pack "$corpus/oot3d_pica_corpus.o3ps" --manifest "$corpus/oot3d_pica_corpus_manifest.json" \
+  --merged-inventory "$corpus/shader-inventory.json.new"
+mv "$corpus/shader-inventory.json.new" "$corpus/shader-inventory.json"
+
+if [[ -f "$captures/pipeline-inventory.json" ]]; then
+  pipelines=()
+  [[ -f "$corpus/oot3d_pica_corpus_pipelines.json" ]] && pipelines+=(--inventory "$corpus/oot3d_pica_corpus_pipelines.json")
+  "$runtime/oot3d_native_pica_pipeline_manifest" \
+    "${pipelines[@]}" --inventory "$captures/pipeline-inventory.json" \
+    --output "$corpus/oot3d_pica_corpus_pipelines.json.new"
+  mv "$corpus/oot3d_pica_corpus_pipelines.json.new" "$corpus/oot3d_pica_corpus_pipelines.json"
+fi
+# Archive the session so it is never merged twice and never lost.
+mv "$captures/shader-inventory.json" "$archive/"
+[[ -f "$captures/pipeline-inventory.json" ]] && mv "$captures/pipeline-inventory.json" "$archive/"
+printf 'Session archived to %s\n' "$archive"

--- a/scripts/run-linux-title.sh
+++ b/scripts/run-linux-title.sh
@@ -39,6 +39,10 @@ shader_args=()
 if [[ -f "$runtime/oot3d_pica_default.o3ps" ]]; then
   shader_args+=(--pica-aot-shader-pack "$runtime/oot3d_pica_default.o3ps")
 fi
+# Overlap guest execution with rendering on a second thread.
+if [[ "${TRIAEVUM_GUEST_THREAD:-0}" == 1 ]]; then
+  shader_args+=(--guest-thread)
+fi
 capture_args=()
 # Readback deliberately stalls the device. Interactive previews must not pay
 # for periodic captures; opt in explicitly when collecting image evidence.

--- a/scripts/run-linux-title.sh
+++ b/scripts/run-linux-title.sh
@@ -35,9 +35,53 @@ cd "$installation"
 mkdir -p linux-captures
 python3 "$root/tools/triaevum_release/prepare_linux_launch.py" \
   "$installation" "$title/triaevum_title_aot.so"
+# Default: the checked-in baseline pack. TRIAEVUM_PICA_CORPUS=1 selects the
+# local candidate built by scripts/extend-pica-corpus.sh (never the baseline).
+pack="$runtime/oot3d_pica_default.o3ps"
+pipelines=""
+if [[ "${TRIAEVUM_PICA_CORPUS:-0}" == 1 ]]; then
+  pack="$runtime/pica-corpus/oot3d_pica_corpus.o3ps"
+  pipelines="$runtime/pica-corpus/oot3d_pica_corpus_pipelines.json"
+  test -f "$pack"
+fi
 shader_args=()
-if [[ -f "$runtime/oot3d_pica_default.o3ps" ]]; then
-  shader_args+=(--pica-aot-shader-pack "$runtime/oot3d_pica_default.o3ps")
+# Forge-generated profiles may already carry the shipped pack (and prewarm
+# manifest); the runtime rejects duplicate options, so add ours only when the
+# profile has none and refuse a profile that already has more than one.
+pack_options=$(python3 - "$installation/TriAevum.linux.launch.json" <<'EOF'
+import json, sys
+try:
+    print(json.load(open(sys.argv[1]))["arguments"].count("--pica-aot-shader-pack"))
+except (OSError, ValueError, KeyError, AttributeError) as exc:
+    sys.exit(f"Launch profile is unusable: {exc}")
+EOF
+) || exit 2
+if [[ "$pack_options" -gt 1 ]]; then
+  printf 'Launch profile lists --pica-aot-shader-pack %s times\n' "$pack_options" >&2
+  exit 2
+fi
+if [[ -f "$pack" && "$pack_options" == 0 ]]; then
+  shader_args+=(--pica-aot-shader-pack "$pack")
+fi
+# Strict: any shader outside the pack aborts the run. Validation replay only.
+if [[ "${TRIAEVUM_PICA_STRICT:-0}" == 1 ]]; then
+  shader_args+=(--pica-aot-shader-strict)
+fi
+# Record every effective PICA shader and pipeline so the AOT pack and prewarm
+# manifest can be extended past the boot/title/Kokiri baseline
+# (see docs/OOT3D_NRI_PICA_AOT_RENDERER_PARITY.md). Written at renderer
+# shutdown: close the window normally, do not SIGTERM.
+if [[ "${TRIAEVUM_SHADER_INVENTORY:-0}" == 1 ]]; then
+  shader_args+=(--pica-effective-shader-inventory
+    "$installation/linux-captures/shader-inventory.json"
+    --pica-pipeline-inventory
+    "$installation/linux-captures/pipeline-inventory.json")
+fi
+# Create every manifest pipeline before the first frame instead of on first use.
+# Requires the candidate corpus: manifest and pack come from the same sessions.
+if [[ "${TRIAEVUM_PIPELINE_PREWARM:-0}" == 1 ]]; then
+  test -f "$pipelines"
+  shader_args+=(--pica-pipeline-manifest "$pipelines" --pica-pipeline-prewarm)
 fi
 capture_args=()
 # Readback deliberately stalls the device. Interactive previews must not pay
@@ -47,8 +91,10 @@ if [[ "${TRIAEVUM_CAPTURE_FRAMES:-0}" == 1 ]]; then
     --screenshot-start-frame 120 --screenshot-interval 300 --screenshot-sequence)
 fi
 # Keep the copied Windows profile unchanged; duplicate plugin options are forbidden.
+# stdout is block-buffered into the tee pipe; without misses to fill it the
+# progress lines never appear, so line-buffer it.
 timeout --signal=TERM --kill-after=5 "$((seconds + 30))" \
-  "$runtime/TriAevum" --launch-profile "$installation/TriAevum.linux.launch.json" \
+  stdbuf -oL "$runtime/TriAevum" --launch-profile "$installation/TriAevum.linux.launch.json" \
   "${shader_args[@]}" \
   --frames 0 --max-seconds "$seconds" \
   --output "$installation/linux-captures/runtime.json" \

--- a/tools/oot3d/native_demo_host/oot3d_demo_host_types.h
+++ b/tools/oot3d/native_demo_host/oot3d_demo_host_types.h
@@ -100,6 +100,8 @@ struct Args {
     // bootstrap supplies one complete simulation step per host frame while
     // the host disables VSync and its SDL software frame limiter.
     bool ThroughputBenchmark = false;
+    // Runs guest execution on its own thread so it overlaps rendering.
+    bool GuestThread = false;
     double MaxSeconds = 0.0;
     double FixedDeltaSeconds = 0.0;
     std::filesystem::path InputTimelinePath;

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -764,6 +764,22 @@ struct NativeCandidateDispatchState {
   std::array<uint64_t, 4> TopScreenItemQueryTrueResults{};
   uint64_t TopScreenSlotItemAttempts = 0;
   uint64_t TopScreenSlotItemOverrides = 0;
+  uint64_t TopScreenItemQueryEntries = 0;
+  uint64_t TopScreenSlotItemEntries = 0;
+  uint64_t TopScreenZrHeldFrames = 0;
+  uint64_t TopScreenZlHeldFrames = 0;
+  bool TopScreenZrPressLatched = false;
+  bool TopScreenZlPressLatched = false;
+  uint32_t TopScreenZrPressLatchFrames = 0U;
+  uint32_t TopScreenZlPressLatchFrames = 0U;
+  bool PreviousPhysicalZrHeld = false;
+  bool PreviousPhysicalZlHeld = false;
+  bool TopScreenZrHostEdgePending = false;
+  bool TopScreenZlHostEdgePending = false;
+  uint64_t TopScreenZrHostEdges = 0;
+  uint64_t TopScreenZlHostEdges = 0;
+  uint64_t TopScreenZrGuestEdges = 0;
+  uint64_t TopScreenZlGuestEdges = 0;
   uint64_t TopScreenSlotItemNativeFallbacks = 0;
   Oot3dNativeGame::Oot3dNativeUiLifecycleBridge *UiLifecycleBridge = nullptr;
   Oot3dNativeGame::Oot3dPicaCompositionDomain *PicaCompositionDomain =
@@ -1426,6 +1442,7 @@ bool ExecuteTopScreenUiSourcePortBlock(
     return true;
   }
   if (pc == kGlobalActionStateGetSlotItemId) {
+    ++dispatch.TopScreenSlotItemEntries;
     if (!Oot3dNativeGame::HasTopScreenSlotItemOverrideInput(
             dispatch.TopScreenInput)) {
       return false;
@@ -1453,6 +1470,7 @@ bool ExecuteTopScreenUiSourcePortBlock(
        Oot3dNativeGame::TopScreenVerifiedItemQueryContracts()) {
     if (contract.OriginalEntry != pc)
       continue;
+    ++dispatch.TopScreenItemQueryEntries;
     if (!Oot3dNativeGame::HasTopScreenItemQueryOverrideInput(
             dispatch.TopScreenInput)) {
       return false;
@@ -1465,6 +1483,17 @@ bool ExecuteTopScreenUiSourcePortBlock(
       return false;
     }
     dispatch.TopScreenItemQueryTrueResults[index] += *resolved ? 1U : 0U;
+    // A press edge lives for one guest frame, but the game polls this getter
+    // on its own schedule. Consume the latched edge only once the guest has
+    // actually observed it as pressed.
+    if (*resolved && contract.Query == Oot3dNativeGame::TopScreenItemQuery::ItemIPressed) {
+      dispatch.TopScreenZrPressLatched = false;
+      dispatch.TopScreenZrPressLatchFrames = 0U;
+    }
+    if (*resolved && contract.Query == Oot3dNativeGame::TopScreenItemQuery::ItemIIPressed) {
+      dispatch.TopScreenZlPressLatched = false;
+      dispatch.TopScreenZlPressLatchFrames = 0U;
+    }
     state.r[0] = *resolved ? 1U : 0U;
     nextPc = state.r[14];
     state.r[15] = nextPc;
@@ -1606,9 +1635,18 @@ bool ExecuteProductTopScreenCamera(uint32_t pc, oot3d::recomp::a32::GuestState &
                                    uint32_t blockBudget, uint32_t *blocksConsumed, void *user) {
   auto &dispatch = *static_cast<NativeCandidateDispatchState *>(user);
   // Product opt-in UI mod, not the experimental source/gameplay dispatcher.
+  // Camera hooks plus the ZL/ZR item-slot getters; every other PC stays in
+  // compiled code.
+  const bool itemQueryEntry = std::any_of(
+      Oot3dNativeGame::TopScreenVerifiedItemQueryContracts().begin(),
+      Oot3dNativeGame::TopScreenVerifiedItemQueryContracts().end(),
+      [pc](const Oot3dNativeGame::TopScreenItemQueryContract &contract) {
+        return contract.OriginalEntry == pc;
+      });
   if (!dispatch.TopScreenUiProfile || dispatch.Memory == nullptr ||
       (pc != kTopScreenCameraUpdateEntry && pc != kTopScreenCameraUpdatePatchSite &&
-       pc != kTopScreenCameraNormal1Scalar)) return false;
+       pc != kTopScreenCameraNormal1Scalar && !itemQueryEntry &&
+       pc != kGlobalActionStateGetSlotItemId)) return false;
   const bool handled = ExecuteTopScreenUiSourcePortBlock(pc, state, dispatch, result, blocksConsumed);
   if (handled) return true;
   // This entry was already observed before returning to the dispatcher. If
@@ -1848,15 +1886,26 @@ void ApplyNativeWidescreenProjectionPolicy(
       [pc](const Oot3dNativeGame::TopScreenItemQueryContract &contract) {
         return contract.OriginalEntry == pc;
       });
+  // Exit to the dispatcher only when the typed replacement will handle the
+  // call. A declined hook cannot resume the compiled block in product mode,
+  // so an input-only gate would spin on the same entry while ZL/ZR is held.
   const bool enabledTopScreenItemExit =
       runtime.TopScreenInput == nullptr ||
+      runtime.TraceMemory == nullptr ||
       (!itemQueryEntry && pc != kGlobalActionStateGetSlotItemId) ||
       (itemQueryEntry &&
        Oot3dNativeGame::HasTopScreenItemQueryOverrideInput(
-           *runtime.TopScreenInput)) ||
+           *runtime.TopScreenInput) &&
+       Oot3dNativeGame::ResolveTopScreenItemQueryGuest(
+           *runtime.TraceMemory, pc, *runtime.TopScreenInput)
+           .has_value()) ||
       (pc == kGlobalActionStateGetSlotItemId &&
        Oot3dNativeGame::HasTopScreenSlotItemOverrideInput(
-           *runtime.TopScreenInput));
+           *runtime.TopScreenInput) &&
+       Oot3dNativeGame::ResolveTopScreenSlotItemOverrideGuest(
+           *runtime.TraceMemory, state.r[0],
+           static_cast<uint8_t>(state.r[1]), *runtime.TopScreenInput)
+           .has_value());
 #if defined(OOT3D_NATIVE_DIRECT_AOT_PLUGIN)
   const bool wholeAotExecutionActive =
       Oot3dNativeGame::Oot3dWholeAotPluginExecutionActive();
@@ -3678,15 +3727,17 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         wholeAotObservableExitBlocks.end(),
         topScreenObservableExitBlocks.begin(),
         topScreenObservableExitBlocks.end());
+#else
+    wholeAotObservableExitBlocks.push_back(kTopScreenCameraUpdateEntry);
+    wholeAotObservableExitBlocks.push_back(kTopScreenCameraNormal1Scalar);
+#endif
+    // ZL/ZR item slots. The block-entry gate above exits only when the
+    // override resolves, so ordinary play never leaves compiled code here.
     for (const auto &contract :
          Oot3dNativeGame::TopScreenVerifiedItemQueryContracts()) {
       wholeAotObservableExitBlocks.push_back(contract.OriginalEntry);
     }
     wholeAotObservableExitBlocks.push_back(kGlobalActionStateGetSlotItemId);
-#else
-    wholeAotObservableExitBlocks.push_back(kTopScreenCameraUpdateEntry);
-    wholeAotObservableExitBlocks.push_back(kTopScreenCameraNormal1Scalar);
-#endif
     nativeCandidateEntries.insert(nativeCandidateEntries.end(),
                                   topScreenSourcePortBlocks.begin(),
                                   topScreenSourcePortBlocks.end());
@@ -4642,6 +4693,14 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     nativeCandidateDispatch.TopScreenGameplayActionRuntime = {};
     nativeCandidateDispatch.PreviousTopScreenZrHeld = false;
     nativeCandidateDispatch.PreviousTopScreenZlHeld = false;
+    nativeCandidateDispatch.TopScreenZrPressLatched = false;
+    nativeCandidateDispatch.TopScreenZlPressLatched = false;
+    nativeCandidateDispatch.TopScreenZrPressLatchFrames = 0U;
+    nativeCandidateDispatch.TopScreenZlPressLatchFrames = 0U;
+    nativeCandidateDispatch.PreviousPhysicalZrHeld = false;
+    nativeCandidateDispatch.PreviousPhysicalZlHeld = false;
+    nativeCandidateDispatch.TopScreenZrHostEdgePending = false;
+    nativeCandidateDispatch.TopScreenZlHostEdgePending = false;
     nativeCandidateDispatch.PreviousTopScreenButtons = 0U;
     nativeCandidateDispatch.StartButtonLatch = {};
     nativeCandidateDispatch.TopScreenStartRouting = {};
@@ -4844,6 +4903,24 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       Oot3dNativeGame::ReleaseTopScreenStartRoutingLatch(
           physicalStartHeld, nativeCandidateDispatch.TopScreenStartRouting);
     }
+    {
+      // Host-rate trigger edges. A tap shorter than one guest refresh would
+      // never be seen by the guest-rate edge below; carry it forward.
+      const bool zrPhysical = ThreeDsRecomp::Input::IsButtonHeld(
+          physicalInputFrame, ThreeDsRecomp::Input::Button::Zr);
+      const bool zlPhysical = ThreeDsRecomp::Input::IsButtonHeld(
+          physicalInputFrame, ThreeDsRecomp::Input::Button::Zl);
+      if (zrPhysical && !nativeCandidateDispatch.PreviousPhysicalZrHeld) {
+        ++nativeCandidateDispatch.TopScreenZrHostEdges;
+        nativeCandidateDispatch.TopScreenZrHostEdgePending = true;
+      }
+      if (zlPhysical && !nativeCandidateDispatch.PreviousPhysicalZlHeld) {
+        ++nativeCandidateDispatch.TopScreenZlHostEdges;
+        nativeCandidateDispatch.TopScreenZlHostEdgePending = true;
+      }
+      nativeCandidateDispatch.PreviousPhysicalZrHeld = zrPhysical;
+      nativeCandidateDispatch.PreviousPhysicalZlHeld = zlPhysical;
+    }
     Oot3dNativeGame::NativeA32InputFrame inputFrame;
     api.UpdateFramebufferParameters(0, width, height, 1, false, true, true,
                                     true);
@@ -4934,17 +5011,44 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             inputFrame, ThreeDsRecomp::Input::Button::Zr);
         const bool zlHeld = ThreeDsRecomp::Input::IsButtonHeld(
             inputFrame, ThreeDsRecomp::Input::Button::Zl);
+        // Any host-rate rising edge since the last guest refresh counts; a
+        // timeline drives the guest frame directly and has no host edges.
+        const bool zrEdge =
+            (zrHeld && !nativeCandidateDispatch.PreviousTopScreenZrHeld) ||
+            (!inputTimeline.Enabled() &&
+             nativeCandidateDispatch.TopScreenZrHostEdgePending) ||
+            topScreenDpadActions.WasPressed(
+                Oot3dNativeGame::TopScreenDpadAction::ItemZr);
+        const bool zlEdge =
+            (zlHeld && !nativeCandidateDispatch.PreviousTopScreenZlHeld) ||
+            (!inputTimeline.Enabled() &&
+             nativeCandidateDispatch.TopScreenZlHostEdgePending) ||
+            topScreenDpadActions.WasPressed(
+                Oot3dNativeGame::TopScreenDpadAction::ItemZl);
+        nativeCandidateDispatch.TopScreenZrHostEdgePending = false;
+        nativeCandidateDispatch.TopScreenZlHostEdgePending = false;
+        nativeCandidateDispatch.TopScreenZrGuestEdges += zrEdge ? 1U : 0U;
+        nativeCandidateDispatch.TopScreenZlGuestEdges += zlEdge ? 1U : 0U;
+        // Keep a press pending until the guest's pressed getter consumes it
+        // (see the item-query hook), surviving a release that happens before
+        // the game polls. Expire after a few guest frames so a press made
+        // outside gameplay cannot fire later.
+        constexpr uint32_t kTopScreenPressLatchFrames = 6U;
+        const auto latch = [](bool edge, uint32_t &framesLeft) {
+          if (edge) {
+            framesLeft = kTopScreenPressLatchFrames;
+          } else if (framesLeft != 0U) {
+            --framesLeft;
+          }
+          return framesLeft != 0U;
+        };
+        nativeCandidateDispatch.TopScreenZrPressLatched =
+            latch(zrEdge, nativeCandidateDispatch.TopScreenZrPressLatchFrames);
+        nativeCandidateDispatch.TopScreenZlPressLatched =
+            latch(zlEdge, nativeCandidateDispatch.TopScreenZlPressLatchFrames);
         nativeCandidateDispatch.TopScreenInput = {
-            .ZrPressed =
-                (zrHeld &&
-                 !nativeCandidateDispatch.PreviousTopScreenZrHeld) ||
-                topScreenDpadActions.WasPressed(
-                    Oot3dNativeGame::TopScreenDpadAction::ItemZr),
-            .ZlPressed =
-                (zlHeld &&
-                 !nativeCandidateDispatch.PreviousTopScreenZlHeld) ||
-                topScreenDpadActions.WasPressed(
-                    Oot3dNativeGame::TopScreenDpadAction::ItemZl),
+            .ZrPressed = nativeCandidateDispatch.TopScreenZrPressLatched,
+            .ZlPressed = nativeCandidateDispatch.TopScreenZlPressLatched,
             .ZrHeld =
                 zrHeld ||
                 topScreenDpadActions.IsHeld(
@@ -4982,6 +5086,8 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             zrHeld;
         nativeCandidateDispatch.PreviousTopScreenZlHeld =
             zlHeld;
+        nativeCandidateDispatch.TopScreenZrHeldFrames += zrHeld ? 1U : 0U;
+        nativeCandidateDispatch.TopScreenZlHeldFrames += zlHeld ? 1U : 0U;
         if (nativeCandidateDispatch.TopScreenUiProfile &&
             activeTopScreenConfig.FreeCameraEnabled &&
             nativeControlPollingState.GameplayMouseOwned) {
@@ -8741,6 +8847,22 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                     nativeCandidateDispatch.TopScreenSlotItemOverrides},
                    {"topscreen_slot_item_native_fallbacks",
                     nativeCandidateDispatch.TopScreenSlotItemNativeFallbacks},
+                   {"topscreen_item_query_entries",
+                    nativeCandidateDispatch.TopScreenItemQueryEntries},
+                   {"topscreen_slot_item_entries",
+                    nativeCandidateDispatch.TopScreenSlotItemEntries},
+                   {"topscreen_input_zr_held_frames",
+                    nativeCandidateDispatch.TopScreenZrHeldFrames},
+                   {"topscreen_input_zl_held_frames",
+                    nativeCandidateDispatch.TopScreenZlHeldFrames},
+                   {"topscreen_input_zr_host_edges",
+                    nativeCandidateDispatch.TopScreenZrHostEdges},
+                   {"topscreen_input_zl_host_edges",
+                    nativeCandidateDispatch.TopScreenZlHostEdges},
+                   {"topscreen_input_zr_guest_edges",
+                    nativeCandidateDispatch.TopScreenZrGuestEdges},
+                   {"topscreen_input_zl_guest_edges",
+                    nativeCandidateDispatch.TopScreenZlGuestEdges},
                    {"candidate_samples", nativeCandidateDispatch.Samples},
                    {"candidate_estimated_seconds",
                     candidateSampleNanoseconds * kA32RuntimeSampleDenominator *

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -4767,9 +4767,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                                             lastPresentationTime)
                   .count();
     lastPresentationTime = presentationTime;
-    const auto presentationStep =
-        presentationScheduler.Advance(presentationElapsedSeconds);
-    const uint32_t guestRefreshesDue = presentationStep.GuestRefreshesDue;
+    // Startup shader precompilation (Citra-style "preparing shaders"): hold
+    // the guest so no draw reaches a pipeline before it is created.
+    const bool shaderPrewarmHold =
+        api.NativePicaPipelinePrewarmProgress().Blocking;
+    const auto presentationStep = presentationScheduler.Advance(
+        shaderPrewarmHold ? 0.0 : presentationElapsedSeconds);
+    uint32_t guestRefreshesDue = presentationStep.GuestRefreshesDue;
     const float visualInterpolationAlpha = static_cast<float>(
         std::clamp(presentationStep.InterpolationAlpha, 0.0, 1.0));
     applyTopScreenConfigSnapshot();
@@ -4848,6 +4852,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     api.UpdateFramebufferParameters(0, width, height, 1, false, true, true,
                                     true);
     api.StartFrame();
+    // StartFrame may have detected a new renderer profile and queued its
+    // batch; drop this frame's refresh rather than let a draw race it.
+    if (api.NativePicaPipelinePrewarmProgress().Blocking) {
+      guestRefreshesDue = 0U;
+    }
     picaPresentationScheduler.BeginPresentation(presentationFrameCount);
     api.StartDrawToFramebuffer(0, 1.0F);
     api.SetClearColor(0.0F, 0.0F, 0.0F, 1.0F);

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -4231,6 +4231,8 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       latestVisualFrame;
   std::optional<Oot3dNativeGame::Oot3dPicaVisualFrame>
       previousVisualFrame;
+  uint64_t topScreenOcarinaRelocatedFrames = 0;
+  uint64_t topScreenOcarinaRelocatedDraws = 0;
   bool latestVisualTransitionContinuous = false;
   uint64_t visualContinuityEpoch = 1U;
   std::map<uint32_t, Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission>
@@ -5560,6 +5562,21 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
           Oot3dNativeGame::PublishNativeActorInteractions(
               process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress,
               in.CurrentVisualFrame->Sequence);
+          if (launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen &&
+              in.SelectedBottom.has_value()) {
+            bool ocarinaUiActive = false;
+            if (Oot3dNativeGame::ReadTopScreenOcarinaUiActive(
+                    process.Memory(), &ocarinaUiActive) &&
+                ocarinaUiActive) {
+              Oot3dNativeGame::TopScreenOcarinaRelocationStats stats;
+              if (Oot3dNativeGame::RelocateTopScreenOcarinaDraws(
+                      *in.CurrentVisualFrame,
+                      in.SelectedBottom->InputPhysicalAddress, &stats)) {
+                ++topScreenOcarinaRelocatedFrames;
+                topScreenOcarinaRelocatedDraws += stats.DrawsRelocated;
+              }
+            }
+          }
           Oot3dNativeGame::ComposeTopScreenFrontendFrame(
               *in.CurrentVisualFrame,
               Oot3dNativeGame::ShouldSuppressTopScreenFrontendBackdrop(
@@ -7788,6 +7805,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                    {"topscreen_gameplay_composition_observed",
                     nativeCandidateDispatch.TopScreenLowerCompositionSkips !=
                         0U},
+                   {"topscreen_quest_hook_calls",
+                    bridge.topscreen_quest_hook_calls},
+                   {"topscreen_quest_transforms",
+                    bridge.topscreen_quest_transforms},
+                   {"topscreen_quest_hook_failures",
+                    bridge.topscreen_quest_hook_failures},
+                   {"topscreen_ocarina_relocated_frames",
+                    topScreenOcarinaRelocatedFrames},
+                   {"topscreen_ocarina_relocated_draws",
+                    topScreenOcarinaRelocatedDraws},
                    {"backend_profile",
                     uiLifecycleBridge.Runtime().Profile().id},
                    {"matched_entries", bridge.matched_entries},

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -394,6 +394,7 @@ struct NativeWidescreenProjectionState {
   bool TopScreenUiProfile = false;
   Oot3dNativeGame::TopScreenUiConfig TopScreenConfig;
   const Oot3dNativeGame::TopScreenExtendedInputFrame *TopScreenInput = nullptr;
+  const uint32_t *PendingTopScreenItemsSelection = nullptr;
   std::span<const uint32_t> WholeAotObservableExitPcs;
   std::optional<Oot3dNativeGame::TopScreenPauseTargetPlan>
       PendingTopScreenPauseTarget;
@@ -1646,7 +1647,9 @@ bool ExecuteProductTopScreenCamera(uint32_t pc, oot3d::recomp::a32::GuestState &
   if (!dispatch.TopScreenUiProfile || dispatch.Memory == nullptr ||
       (pc != kTopScreenCameraUpdateEntry && pc != kTopScreenCameraUpdatePatchSite &&
        pc != kTopScreenCameraNormal1Scalar && !itemQueryEntry &&
-       pc != kGlobalActionStateGetSlotItemId)) return false;
+       pc != kGlobalActionStateGetSlotItemId &&
+       pc != kPauseItemsNativeUpdateCall &&
+       pc != kPauseItemsNativeUpdateReturn)) return false;
   const bool handled = ExecuteTopScreenUiSourcePortBlock(pc, state, dispatch, result, blocksConsumed);
   if (handled) return true;
   // This entry was already observed before returning to the dispatcher. If
@@ -1889,10 +1892,27 @@ void ApplyNativeWidescreenProjectionPolicy(
   // Exit to the dispatcher only when the typed replacement will handle the
   // call. A declined hook cannot resume the compiled block in product mode,
   // so an input-only gate would spin on the same entry while ZL/ZR is held.
+  const auto pauseItemsPageState = [&]() {
+    uint32_t pageState = 0U;
+    return runtime.TraceMemory != nullptr &&
+                   runtime.TraceMemory->Read32(0x0050672CU, &pageState)
+               ? pageState
+               : 0U;
+  };
   const bool enabledTopScreenItemExit =
       runtime.TopScreenInput == nullptr ||
       runtime.TraceMemory == nullptr ||
-      (!itemQueryEntry && pc != kGlobalActionStateGetSlotItemId) ||
+      (!itemQueryEntry && pc != kGlobalActionStateGetSlotItemId &&
+       pc != kPauseItemsNativeUpdateCall &&
+       pc != kPauseItemsNativeUpdateReturn) ||
+      (pc == kPauseItemsNativeUpdateCall &&
+       Oot3dNativeGame::ResolveTopScreenItemsSelectionBegin(
+           {runtime.TopScreenInput->ZrPressed,
+            runtime.TopScreenInput->ZlPressed, pauseItemsPageState()})
+           .Active) ||
+      (pc == kPauseItemsNativeUpdateReturn &&
+       runtime.PendingTopScreenItemsSelection != nullptr &&
+       *runtime.PendingTopScreenItemsSelection != 0U) ||
       (itemQueryEntry &&
        Oot3dNativeGame::HasTopScreenItemQueryOverrideInput(
            *runtime.TopScreenInput) &&
@@ -3738,6 +3758,9 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       wholeAotObservableExitBlocks.push_back(contract.OriginalEntry);
     }
     wholeAotObservableExitBlocks.push_back(kGlobalActionStateGetSlotItemId);
+    // Items page: ZR/ZL assign the hovered item to Item I/II without touch.
+    wholeAotObservableExitBlocks.push_back(kPauseItemsNativeUpdateCall);
+    wholeAotObservableExitBlocks.push_back(kPauseItemsNativeUpdateReturn);
     nativeCandidateEntries.insert(nativeCandidateEntries.end(),
                                   topScreenSourcePortBlocks.begin(),
                                   topScreenSourcePortBlocks.end());
@@ -3832,6 +3855,8 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 #endif
   widescreenProjection.TopScreenInput =
       &nativeCandidateDispatch.TopScreenInput;
+  widescreenProjection.PendingTopScreenItemsSelection =
+      &nativeCandidateDispatch.PendingTopScreenItemsSelection;
   nativeCandidateDispatch.UiLifecycleBridge = &uiLifecycleBridge;
   nativeCandidateDispatch.PicaCompositionDomain = &picaCompositionDomain;
   nativeCandidateDispatch.TopScreenPauseProjection =

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -107,6 +107,11 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <condition_variable>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <thread>
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -3981,6 +3986,81 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 #endif
 
   NativeFramePhaseTiming phaseTiming;
+  // Runs one unit of guest work per presentation on a persistent thread and
+  // joins it before main touches guest state again. With the guest thread
+  // disabled the same units execute inline, so both modes share one loop.
+  struct GuestWorker {
+    explicit GuestWorker(bool threaded) : Threaded(threaded) {
+      if (Threaded) {
+        Thread = std::thread([this] {
+          for (;;) {
+            std::function<void()> unit;
+            {
+              std::unique_lock lock(Mutex);
+              Ready.wait(lock, [&] { return Pending != nullptr || Quit; });
+              if (Quit && Pending == nullptr) return;
+              unit = std::move(Pending);
+              Pending = nullptr;
+            }
+            try {
+              unit();
+            } catch (...) {
+              std::lock_guard lock(Mutex);
+              Failure = std::current_exception();
+            }
+            {
+              std::lock_guard lock(Mutex);
+              Busy = false;
+            }
+            Done.notify_all();
+          }
+        });
+      }
+    }
+    ~GuestWorker() {
+      if (Thread.joinable()) {
+        {
+          std::lock_guard lock(Mutex);
+          Quit = true;
+        }
+        Ready.notify_all();
+        Thread.join();
+      }
+    }
+    void Run(std::function<void()> unit) {
+      if (!Threaded) {
+        unit();
+        return;
+      }
+      {
+        std::lock_guard lock(Mutex);
+        Pending = std::move(unit);
+        Busy = true;
+      }
+      Ready.notify_all();
+    }
+    // Blocks until the unit finished; rethrows anything it threw.
+    void Wait() {
+      if (!Threaded) return;
+      std::exception_ptr failure;
+      {
+        std::unique_lock lock(Mutex);
+        Done.wait(lock, [&] { return !Busy; });
+        failure = std::exchange(Failure, nullptr);
+      }
+      if (failure) std::rethrow_exception(failure);
+    }
+    const bool Threaded;
+    std::thread Thread;
+    std::mutex Mutex;
+    std::condition_variable Ready;
+    std::condition_variable Done;
+    std::function<void()> Pending;
+    std::exception_ptr Failure;
+    bool Busy = false;
+    bool Quit = false;
+  } guestWorker(hostArgs.GuestThread);
+  bool guestStopRequested = false;
   Oot3dNativeGame::NativeA32InputDiagnostics inputDiagnostics;
   NativeInputConsumerDiagnostics inputConsumerDiagnostics;
   NativeControlPollingState nativeControlPollingState;
@@ -3993,6 +4073,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       Oot3dNativeGame::Oot3dUiProfileName(launch.UiProfile));
   Oot3dNativeGame::NativeA32DspHle dspHle(
       Oot3dNativeGame::BuildNativeA32DspPhysicalRegions(*manifest));
+  std::string hostLoopExitReason = "window_closed";
   auto *context = Ship::Context::GetRawInstance();
   auto audio = context != nullptr ? context->GetAudio() : nullptr;
   auto audioPlayer = audio != nullptr ? audio->GetAudioPlayer() : nullptr;
@@ -4405,30 +4486,41 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
   FramebufferScreenshotState screenshotState;
   uint64_t lastPublishedSceneViewSerial = 0;
   uint64_t publishedSceneViewCount = 0;
+  // Guest side captures the latest scene view; main publishes it to the
+  // renderer once per presentation, before the HUD, as it did inline.
+  std::optional<std::pair<uint64_t, Fast::Oot3d::TitleSceneViewSubmission>>
+      pendingSceneView;
   const auto publishNativeSceneView = [&]() {
     const auto snapshot = sceneViewProbe.Capture(process.Memory());
     if (!snapshot.has_value() ||
-        snapshot->Serial == lastPublishedSceneViewSerial) {
+        snapshot->Serial == lastPublishedSceneViewSerial ||
+        (pendingSceneView.has_value() &&
+         pendingSceneView->first == snapshot->Serial)) {
       return;
     }
-    const Fast::Oot3d::TitleSceneViewSubmission view{
-        snapshot->GuestFunction,
-        snapshot->GuestReturnAddress,
-        snapshot->Left,
-        snapshot->Right,
-        snapshot->Bottom,
-        snapshot->Top,
-        snapshot->NearPlane,
-        snapshot->FarPlane,
-        snapshot->Eye,
-        snapshot->At,
-        snapshot->CameraAvailable,
-    };
+    pendingSceneView = {snapshot->Serial,
+                        Fast::Oot3d::TitleSceneViewSubmission{
+                            snapshot->GuestFunction,
+                            snapshot->GuestReturnAddress,
+                            snapshot->Left,
+                            snapshot->Right,
+                            snapshot->Bottom,
+                            snapshot->Top,
+                            snapshot->NearPlane,
+                            snapshot->FarPlane,
+                            snapshot->Eye,
+                            snapshot->At,
+                            snapshot->CameraAvailable,
+                        }};
+  };
+  const auto flushSceneView = [&]() {
+    if (!pendingSceneView.has_value()) return;
     if (titleRenderBackend != nullptr &&
-        titleRenderBackend->PublishSceneView(view)) {
-      lastPublishedSceneViewSerial = snapshot->Serial;
+        titleRenderBackend->PublishSceneView(pendingSceneView->second)) {
+      lastPublishedSceneViewSerial = pendingSceneView->first;
       ++publishedSceneViewCount;
     }
+    pendingSceneView.reset();
   };
   picaPresentationScheduler.SetTimingEnabled(launch.ExtendedDiagnostics);
   std::optional<Fast::Oot3d::NativeFrameTemporalSample> capturedTemporalSample;
@@ -4831,6 +4923,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                            guestRefreshesDue != 0U,
                            nativeControlPollingState);
     if (physicalInputFrame.Exit) {
+      hostLoopExitReason = "host_input_exit";
       window.Close();
       break;
     }
@@ -4857,12 +4950,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     phaseTiming.FrameStartSeconds += SecondsSince(phaseStart);
     const uint32_t guestRefreshIterations =
         std::max<uint32_t>(1U, guestRefreshesDue);
-    for (uint32_t guestRefreshIndex = 0;
-         guestRefreshIndex < guestRefreshIterations; ++guestRefreshIndex) {
-      const bool advanceGuest = guestRefreshIndex < guestRefreshesDue;
-      const bool presentHostFrame =
-          guestRefreshIndex + 1U == guestRefreshIterations;
-      if (advanceGuest) {
+    // Guest unit 1: input routing and one guest step. Runs on the guest
+    // thread while main waits in StartFrame; touches no renderer state.
+    const auto guestStep = [&](uint32_t guestRefreshIndex) -> bool {
+      // Private to this unit: main uses its own phaseStart/error meanwhile.
+      auto phaseStart = std::chrono::steady_clock::now();
+      std::string error;
+      {
         if (guestRefreshIndex != 0U) {
           nativeFrontendTouchEnabled = ResolveNativeA32TouchInputEnabled(
               process.Memory(), uiLifecycleBridge,
@@ -4889,11 +4983,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             nativeCandidateDispatch.TopScreenStartRouting);
         inputDiagnostics.Observe(inputFrame);
         if (inputFrame.Exit) {
-          window.Close();
-          break;
+          guestStopRequested = true;
+          return false;
         }
       }
-      if (advanceGuest) {
+      {
         const uint32_t topScreenButtons = inputFrame.Hid.Buttons;
         const uint32_t topScreenPressed =
             topScreenButtons &
@@ -5154,13 +5248,13 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             std::cerr << "oot3d_native_game: structural scenario failed: "
                       << scenarioError << '\n';
             if (launch.ScenarioStrict) {
-              window.Close();
-              break;
+              guestStopRequested = true;
+              return false;
             }
           }
           if (launch.ScenarioAutoExit && scenarioBootstrap->Complete()) {
-            window.Close();
-            break;
+            guestStopRequested = true;
+            return false;
           }
         }
         refreshTickRemainder += kCtrArm11TicksPerSecond;
@@ -5250,60 +5344,84 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         }
         ++vblankCount;
       }
-      if (presentHostFrame) {
-        const auto visualPresentationStart = std::chrono::steady_clock::now();
-        const bool lcdForceBlack = hostServices.LcdForceBlack();
-        const auto topFramebuffer = hostServices.TopFramebuffer();
-        const Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission
-            *traceSelectedTopTransfer = nullptr;
-        if (topFramebuffer.has_value()) {
-          auto traceSelected =
-              displayTransfersByOutput.find(topFramebuffer->AddressLeft);
-          if (traceSelected == displayTransfersByOutput.end() &&
-              topFramebuffer->AddressRight != topFramebuffer->AddressLeft) {
-            traceSelected =
-                displayTransfersByOutput.find(topFramebuffer->AddressRight);
-          }
-          if (traceSelected != displayTransfersByOutput.end()) {
-            traceSelectedTopTransfer = &traceSelected->second;
-          }
+      return true;
+    };
+    // Everything the present half needs from guest-side state, gathered on
+    // main while the guest thread is idle. Present then overlaps the drain.
+    struct PresentInputs {
+      bool LcdForceBlack = false;
+      std::optional<Oot3dNativeGame::NativeA32CtrFramebufferState> Top;
+      std::optional<Oot3dNativeGame::NativeA32CtrFramebufferState> Bottom;
+      bool FrontendActive = false;
+      std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission>
+          SelectedTop;
+      std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission>
+          SelectedBottom;
+      std::optional<Oot3dNativeGame::Oot3dPicaVisualFrame> CurrentVisualFrame;
+      uint32_t GuestFrameCount = 0;
+    };
+    const auto gatherPresentInputs = [&]() {
+      PresentInputs in;
+      in.LcdForceBlack = hostServices.LcdForceBlack();
+      in.Top = hostServices.TopFramebuffer();
+      in.Bottom = hostServices.BottomFramebuffer();
+      in.FrontendActive = uiLifecycleBridge.NativeFrontendPresentationActive();
+      in.GuestFrameCount = frameCount;
+      const auto findTransfer = [&](uint32_t left, uint32_t right)
+          -> std::optional<Oot3dNativeGame::Oot3dPicaDisplayTransferSubmission> {
+        auto it = displayTransfersByOutput.find(left);
+        if (it == displayTransfersByOutput.end() && right != 0U && right != left) {
+          it = displayTransfersByOutput.find(right);
         }
-        picaSemanticTrace.RecordPresentationSelection(
-            presentationFrameCount, frameCount, lcdForceBlack,
-            topFramebuffer.has_value()
-                ? std::optional<uint32_t>(topFramebuffer->AddressLeft)
-                : std::nullopt,
-            topFramebuffer.has_value()
-                ? std::optional<uint32_t>(topFramebuffer->AddressRight)
-                : std::nullopt,
-            traceSelectedTopTransfer);
-        if (!lcdForceBlack) {
-          if (topFramebuffer.has_value()) {
-            auto selected =
-                displayTransfersByOutput.find(topFramebuffer->AddressLeft);
-            if (selected == displayTransfersByOutput.end() &&
-                topFramebuffer->AddressRight != topFramebuffer->AddressLeft) {
-              selected =
-                  displayTransfersByOutput.find(topFramebuffer->AddressRight);
-            }
-            if (selected != displayTransfersByOutput.end()) {
+        if (it == displayTransfersByOutput.end()) return std::nullopt;
+        return it->second;
+      };
+      if (in.Top.has_value()) {
+        in.SelectedTop = findTransfer(in.Top->AddressLeft, in.Top->AddressRight);
+      }
+      if (in.Bottom.has_value()) {
+        in.SelectedBottom =
+            findTransfer(in.Bottom->AddressLeft, in.Bottom->AddressRight);
+      }
+      picaSemanticTrace.RecordPresentationSelection(
+          presentationFrameCount, frameCount, in.LcdForceBlack,
+          in.Top.has_value() ? std::optional<uint32_t>(in.Top->AddressLeft)
+                             : std::nullopt,
+          in.Top.has_value() ? std::optional<uint32_t>(in.Top->AddressRight)
+                             : std::nullopt,
+          in.SelectedTop.has_value() ? &*in.SelectedTop : nullptr);
+      if (!in.LcdForceBlack && in.SelectedTop.has_value() &&
+          in.SelectedTop->CompletionId != lastSelectedTopTransferCompletionId) {
+        lastSelectedTopTransferCompletionId = in.SelectedTop->CompletionId;
+        ++selectedTopTransferCount;
+        in.CurrentVisualFrame =
+            picaPresentationScheduler.FinishFrame(*in.SelectedTop);
+        if (in.CurrentVisualFrame.has_value()) {
+          Oot3dNativeGame::PublishNativeActorInteractions(
+              process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress,
+              in.CurrentVisualFrame->Sequence);
+          Oot3dNativeGame::ComposeTopScreenFrontendFrame(
+              *in.CurrentVisualFrame,
+              Oot3dNativeGame::ShouldSuppressTopScreenFrontendBackdrop(
+                  launch.UiProfile, in.FrontendActive));
+        }
+      }
+      return in;
+    };
+    // Present half: only main-thread renderer state plus the snapshot.
+    const auto presentHalf = [&](PresentInputs &in) {
+      const auto visualPresentationStart = std::chrono::steady_clock::now();
+      {
+        if (!in.LcdForceBlack) {
+          if (in.SelectedTop.has_value()) {
+            const auto &selectedTop = *in.SelectedTop;
+            {
               bool presentedVisualSample = false;
               bool selectedNewVisualFrame = false;
-              if (selected->second.CompletionId !=
-                  lastSelectedTopTransferCompletionId) {
-                lastSelectedTopTransferCompletionId =
-                    selected->second.CompletionId;
-                ++selectedTopTransferCount;
-                auto currentVisualFrame =
-                    picaPresentationScheduler.FinishFrame(selected->second);
-                if (currentVisualFrame.has_value()) {
-                  Oot3dNativeGame::PublishNativeActorInteractions(
-                      process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress, currentVisualFrame->Sequence);
-                  Oot3dNativeGame::ComposeTopScreenFrontendFrame(
-                      *currentVisualFrame,
-                      Oot3dNativeGame::ShouldSuppressTopScreenFrontendBackdrop(
-                          launch.UiProfile,
-                          uiLifecycleBridge.NativeFrontendPresentationActive()));
+              if (in.CurrentVisualFrame.has_value()) {
+                auto currentVisualFrame = std::move(in.CurrentVisualFrame);
+                in.CurrentVisualFrame.reset();
+                {
                   selectedNewVisualFrame = true;
                   ++visualSnapshotCount;
                   auto &sample = visualFrameSampleScratch;
@@ -5395,7 +5513,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                               visualTransitionEvents.begin());
                         }
                         visualTransitionEvents.push_back({
-                            {"host_frame", frameCount},
+                            {"host_frame", in.GuestFrameCount},
                             {"previous_sequence",
                              latestVisualFrame->Sequence},
                             {"current_sequence",
@@ -5532,11 +5650,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
               }
               if (!presentedVisualSample &&
                   picaPresentationScheduler.HasSnapshot(
-                      selected->second,
+                      selectedTop,
                       kVisualInterpolationRenderTargetNamespace)) {
                 const auto started = std::chrono::steady_clock::now();
                 if (!picaPresentationScheduler.PresentExisting(
-                        api, selected->second,
+                        api, selectedTop,
                         kVisualInterpolationRenderTargetNamespace, &error)) {
                   throw std::runtime_error(
                       "native top-screen scheduled scanout failed: " + error);
@@ -5549,29 +5667,17 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 
           const bool presentNativeBottomFrontend =
               Oot3dNativeGame::ShouldPresentNativeBottomFrontend(
-                  launch.UiProfile,
-                  uiLifecycleBridge.NativeFrontendPresentationActive());
-          const auto bottomFramebuffer = hostServices.BottomFramebuffer();
-          if (presentNativeBottomFrontend &&
-              bottomFramebuffer.has_value()) {
+                  launch.UiProfile, in.FrontendActive);
+          if (presentNativeBottomFrontend && in.Bottom.has_value()) {
             ++nativeFrontendPresentationActiveCount;
-            auto selectedBottom =
-                displayTransfersByOutput.find(bottomFramebuffer->AddressLeft);
-            if (selectedBottom == displayTransfersByOutput.end() &&
-                bottomFramebuffer->AddressRight != 0U &&
-                bottomFramebuffer->AddressRight !=
-                    bottomFramebuffer->AddressLeft) {
-              selectedBottom = displayTransfersByOutput.find(
-                  bottomFramebuffer->AddressRight);
-            }
             nativeFrontendBottomTransferHitCount +=
-                selectedBottom != displayTransfersByOutput.end() ? 1U : 0U;
-            if (selectedBottom != displayTransfersByOutput.end() &&
+                in.SelectedBottom.has_value() ? 1U : 0U;
+            if (in.SelectedBottom.has_value() &&
                 picaPresentationScheduler.HasSnapshot(
-                    selectedBottom->second,
+                    *in.SelectedBottom,
                     kVisualInterpolationRenderTargetNamespace)) {
               if (!picaPresentationScheduler.PresentExisting(
-                      api, selectedBottom->second,
+                      api, *in.SelectedBottom,
                       kVisualInterpolationRenderTargetNamespace, &error)) {
                 throw std::runtime_error(
                     "native bottom-screen frontend presentation failed: " +
@@ -5584,7 +5690,15 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         phaseTiming.VisualPresentationSeconds +=
             SecondsSince(visualPresentationStart);
       }
-      if (advanceGuest) {
+    };
+    // Guest unit 2: run to the next wait and drain the PICA queue into the
+    // accumulator. Overlaps the present half; touches no renderer state
+    // except through the scene-view mailbox.
+    const auto guestDrain = [&]() {
+      // Private to this unit: main uses its own phaseStart/error meanwhile.
+      auto phaseStart = std::chrono::steady_clock::now();
+      std::string error;
+      {
         phaseStart = std::chrono::steady_clock::now();
         processResult =
             RunUntilGuestWait(process, launch.WholeAotBlockBudget);
@@ -6033,52 +6147,96 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         refreshesWithNativeDraws += refreshHadNativeDraws ? 1U : 0U;
         phaseTiming.PicaSubmitSeconds += SecondsSince(picaSubmitStart);
       }
-      frameCount += advanceGuest ? 1U : 0U;
-    }
-
-    if (launch.ExtendedDiagnostics) {
-      inputConsumerDiagnostics.Observe(process.Memory(), frameCount);
-    }
-
-    for (std::size_t subsystemIndex = 0;
-         subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
-      const auto subsystem =
-          static_cast<oot3d::ui::UiSubsystem>(subsystemIndex);
-      const bool topScreenProfile =
-          launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen;
-      if (topScreenProfile &&
-          subsystem != oot3d::ui::UiSubsystem::GameplayHud &&
-          subsystem != oot3d::ui::UiSubsystem::Map) {
-        continue;
+      ++frameCount;
+      if (launch.ExtendedDiagnostics) {
+        inputConsumerDiagnostics.Observe(process.Memory(), frameCount);
       }
-      const bool topScreenPresentation = topScreenProfile;
-      if (!topScreenPresentation && !uiLifecycleBridge.Runtime()
-                                         .PlanFrame(subsystem)
-                                         .run_host_presentation) {
-        continue;
+    };
+    // Guest unit 3: build UI primitives from guest memory. Runs after the
+    // drain on the guest thread; main renders them afterwards.
+    std::array<std::optional<std::vector<oot3d::ui::UiPrimitive>>,
+               oot3d::ui::kUiSubsystemCount>
+        hudPrimitives;
+    const auto buildHud = [&]() {
+      for (std::size_t subsystemIndex = 0;
+           subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
+        hudPrimitives[subsystemIndex].reset();
+        const auto subsystem =
+            static_cast<oot3d::ui::UiSubsystem>(subsystemIndex);
+        const bool topScreenProfile =
+            launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen;
+        if (topScreenProfile &&
+            subsystem != oot3d::ui::UiSubsystem::GameplayHud &&
+            subsystem != oot3d::ui::UiSubsystem::Map) {
+          continue;
+        }
+        if (!topScreenProfile && !uiLifecycleBridge.Runtime()
+                                      .PlanFrame(subsystem)
+                                      .run_host_presentation) {
+          continue;
+        }
+        auto primitives =
+            topScreenProfile
+                ? uiLifecycleBridge.BuildTopScreenPresentation(subsystem)
+                : uiLifecycleBridge.BuildShadowPresentation(subsystem);
+        if (topScreenProfile &&
+            subsystem == oot3d::ui::UiSubsystem::GameplayHud) {
+          Oot3dNativeGame::AppendTopScreenFreeCameraOptionPresentation(
+              nativeCandidateDispatch.TopScreenCamera.Camera, primitives);
+        }
+        if (topScreenProfile) {
+          lastTopScreenPrimitivesBySubsystem[subsystemIndex] = primitives;
+        }
+        hudPrimitives[subsystemIndex] = std::move(primitives);
       }
-      auto primitives =
-          topScreenPresentation
-              ? uiLifecycleBridge.BuildTopScreenPresentation(subsystem)
-              : uiLifecycleBridge.BuildShadowPresentation(subsystem);
-      if (topScreenPresentation &&
-          subsystem == oot3d::ui::UiSubsystem::GameplayHud) {
-        Oot3dNativeGame::AppendTopScreenFreeCameraOptionPresentation(
-            nativeCandidateDispatch.TopScreenCamera.Camera, primitives);
-      }
-      if (topScreenPresentation) {
-        lastTopScreenPrimitivesBySubsystem[subsystemIndex] = primitives;
-      }
+    };
+    const auto renderHud = [&]() {
       const auto canvasMode =
-          topScreenPresentation
+          launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen
               ? oot3d::ui::N64UiCanvasMode::NativeTopScreen400x240
               : oot3d::ui::N64UiCanvasMode::Widescreen16x9;
-      if (!n64UiRenderer.Render(primitives, width, height, canvasMode,
-                                &error)) {
-        throw std::runtime_error("integrated N64 UI presentation failed: " +
-                                 error);
+      for (auto &primitives : hudPrimitives) {
+        if (!primitives.has_value()) continue;
+        if (!n64UiRenderer.Render(*primitives, width, height, canvasMode,
+                                  &error)) {
+          throw std::runtime_error("integrated N64 UI presentation failed: " +
+                                   error);
+        }
       }
+    };
+
+    // Sequence per presentation. Units run inline unless --guest-thread.
+    //   guest:  step(0) ... step(n-1)+drain   |   present inputs   |   drain(n) + HUD build
+    //   main:   StartFrame (already done)     |   (guest idle)     |   present half
+    // Guest-memory reads keep their original phase relative to guest steps.
+    guestStopRequested = false;
+    guestWorker.Run([&] {
+      for (uint32_t guestRefreshIndex = 0;
+           guestRefreshIndex + 1U < guestRefreshesDue; ++guestRefreshIndex) {
+        if (!guestStep(guestRefreshIndex)) return;
+        guestDrain();
+      }
+      if (guestRefreshesDue != 0U) {
+        guestStep(guestRefreshesDue - 1U);
+      }
+    });
+    guestWorker.Wait();
+    if (guestStopRequested) {
+      hostLoopExitReason = "guest_requested_stop";
+      window.Close();
+      break;
     }
+    PresentInputs presentInputs = gatherPresentInputs();
+    guestWorker.Run([&] {
+      if (guestRefreshesDue != 0U) {
+        guestDrain();
+      }
+      buildHud();
+    });
+    presentHalf(presentInputs);
+    guestWorker.Wait();
+    flushSceneView();
+    renderHud();
 
     phaseStart = std::chrono::steady_clock::now();
     gui->EndDraw();
@@ -6473,6 +6631,8 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             {"run_frames", runFrameCount},
             {"guest_refresh_frames", frameCount},
             {"presentation_frames", presentationFrameCount},
+            {"host_loop_exit_reason", hostLoopExitReason},
+            {"guest_thread", hostArgs.GuestThread},
             {"pica_composition",
              [&]() {
                const auto &stats = picaCompositionTracker.Stats();

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -2725,6 +2725,28 @@ struct NativeControlPollingState {
   double PendingMouseSeconds = 0.0;
   bool GameplayMouseOwned = false;
   Oot3dNativeGame::NativeRightStickProfileState RightStickProfile;
+  // Ocarina song browsing on the single screen. The presenter publishes
+  // whether the performance UI and its song browser are visible and which
+  // tile the game's cursor is on; D-pad Left/Right then step through the
+  // song grid by tapping the tile the game itself takes a touch on, since
+  // the grid is not drawn. A tap on a song Link has not learned is refused
+  // (the cursor stays put and the staff clears), so a step keeps tapping
+  // onward until the cursor moves, or returns to where it started.
+  bool OcarinaUiActive = false;
+  bool OcarinaBrowserVisible = false;
+  int OcarinaCursorTile = -1;
+  bool OcarinaDpadLeftHeld = false;
+  bool OcarinaDpadRightHeld = false;
+  int OcarinaStepDirection = 0;
+  int OcarinaStepOrigin = -1;
+  int OcarinaStepTarget = -1;
+  uint8_t OcarinaStepAttempts = 0;
+  uint8_t OcarinaSettleFramesLeft = 0;
+  uint8_t OcarinaTouchFramesLeft = 0;
+  uint16_t OcarinaTouchX = 0;
+  uint16_t OcarinaTouchY = 0;
+  uint64_t OcarinaTapsIssued = 0;
+  uint64_t OcarinaStepsRefused = 0;
 };
 
 Oot3dNativeGame::NativeA32InputFrame
@@ -3052,6 +3074,94 @@ PollNativeA32Input(Fast::Fast3dWindow &window,
   frame.Exit = !keyboardCaptured &&
                window.IsKeyDown(Ship::LUS_KB_ESCAPE);
   return frame;
+}
+
+// Single-screen ocarina song browsing. The song grid is not drawn, so D-pad
+// Left/Right step through it by tapping the tile the game itself takes a
+// touch on: four columns by three rows of 68x40 tiles from (18,70) on the
+// lower canvas, with the list icon at the bottom-right corner opening the
+// browser from the free-play page. The consumed D-pad bits are cleared so
+// the TopScreen item-slot actions do not fire while playing.
+void ApplyTopScreenOcarinaBrowsing(NativeControlPollingState &state,
+                                   Oot3dNativeGame::NativeA32HidState &hid) {
+  constexpr int kSongColumns = 4;
+  constexpr int kSongTiles = 12;
+  constexpr uint16_t kListIconX = 290;
+  constexpr uint16_t kListIconY = 225;
+  constexpr uint8_t kTapFrames = 3;
+  // Guest frames for the game to react to a tap before the cursor is read.
+  constexpr uint8_t kSettleFrames = 12;
+  const uint32_t leftMask = Oot3dNativeGame::NativeA32HidButtonMask(
+      Oot3dNativeGame::NativeA32HidButton::DpadLeft);
+  const uint32_t rightMask = Oot3dNativeGame::NativeA32HidButtonMask(
+      Oot3dNativeGame::NativeA32HidButton::DpadRight);
+  const auto tapTile = [&](int tile) {
+    state.OcarinaTouchX =
+        static_cast<uint16_t>(52 + 72 * (tile % kSongColumns));
+    state.OcarinaTouchY =
+        static_cast<uint16_t>(90 + 44 * (tile / kSongColumns));
+    state.OcarinaTouchFramesLeft = kTapFrames;
+    state.OcarinaSettleFramesLeft = kSettleFrames;
+    ++state.OcarinaTapsIssued;
+  };
+  if (!state.OcarinaUiActive) {
+    state.OcarinaDpadLeftHeld = false;
+    state.OcarinaDpadRightHeld = false;
+    state.OcarinaStepDirection = 0;
+    state.OcarinaTouchFramesLeft = 0;
+    state.OcarinaSettleFramesLeft = 0;
+    return;
+  }
+  const bool left = (hid.Buttons & leftMask) != 0U;
+  const bool right = (hid.Buttons & rightMask) != 0U;
+  hid.Buttons &= ~(leftMask | rightMask);
+  const int edge = (right && !state.OcarinaDpadRightHeld) ? 1
+                   : (left && !state.OcarinaDpadLeftHeld) ? -1
+                                                          : 0;
+  state.OcarinaDpadLeftHeld = left;
+  state.OcarinaDpadRightHeld = right;
+
+  if (state.OcarinaStepDirection != 0 && state.OcarinaTouchFramesLeft == 0U) {
+    if (state.OcarinaSettleFramesLeft != 0U) {
+      --state.OcarinaSettleFramesLeft;
+    } else if (state.OcarinaCursorTile == state.OcarinaStepTarget ||
+               state.OcarinaStepTarget == state.OcarinaStepOrigin ||
+               state.OcarinaStepAttempts >= kSongTiles) {
+      state.OcarinaStepDirection = 0;
+    } else {
+      // Refused: try the next tile in the same direction. Reaching the
+      // origin again means nothing else is learned; re-select it so the
+      // staff the refused taps cleared comes back.
+      ++state.OcarinaStepAttempts;
+      ++state.OcarinaStepsRefused;
+      state.OcarinaStepTarget =
+          (state.OcarinaStepTarget + state.OcarinaStepDirection + kSongTiles) %
+          kSongTiles;
+      tapTile(state.OcarinaStepTarget);
+    }
+  }
+  if (edge != 0 && state.OcarinaStepDirection == 0 &&
+      state.OcarinaTouchFramesLeft == 0U) {
+    if (!state.OcarinaBrowserVisible) {
+      state.OcarinaTouchX = kListIconX;
+      state.OcarinaTouchY = kListIconY;
+      state.OcarinaTouchFramesLeft = kTapFrames;
+      ++state.OcarinaTapsIssued;
+    } else if (state.OcarinaCursorTile >= 0) {
+      state.OcarinaStepDirection = edge;
+      state.OcarinaStepOrigin = state.OcarinaCursorTile;
+      state.OcarinaStepTarget =
+          (state.OcarinaCursorTile + edge + kSongTiles) % kSongTiles;
+      state.OcarinaStepAttempts = 1;
+      tapTile(state.OcarinaStepTarget);
+    }
+  }
+  if (state.OcarinaTouchFramesLeft != 0U) {
+    --state.OcarinaTouchFramesLeft;
+    hid.TouchX = state.OcarinaTouchX;
+    hid.TouchY = state.OcarinaTouchY;
+    hid.TouchPressed = true;
+  }
 }
 
 Oot3dNativeGame::NativeA32InputFrame ResolveNativeA32GuestInput(
@@ -5114,6 +5224,10 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             nativeCandidateDispatch.TopScreenUiProfile,
             nativeCandidateDispatch.StartButtonLatch,
             nativeCandidateDispatch.TopScreenStartRouting);
+        if (nativeCandidateDispatch.TopScreenUiProfile) {
+          ApplyTopScreenOcarinaBrowsing(nativeControlPollingState,
+                                        inputFrame.Hid);
+        }
         inputDiagnostics.Observe(inputFrame);
         if (inputFrame.Exit) {
           guestStopRequested = true;
@@ -5521,6 +5635,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
           SelectedBottom;
       std::optional<Oot3dNativeGame::Oot3dPicaVisualFrame> CurrentVisualFrame;
       uint32_t GuestFrameCount = 0;
+      bool OcarinaUiActive = false;
     };
     const auto gatherPresentInputs = [&]() {
       PresentInputs in;
@@ -5562,20 +5677,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
           Oot3dNativeGame::PublishNativeActorInteractions(
               process.Memory(), sceneViewProbe.Stats().LastPlayStateAddress,
               in.CurrentVisualFrame->Sequence);
+          // Guest memory is read here while the guest is idle; the draw
+          // relocation itself runs at present time, after the drain has
+          // refreshed the shared vertex buffers this frame references.
           if (launch.UiProfile == Oot3dNativeGame::Oot3dUiProfile::TopScreen &&
               in.SelectedBottom.has_value()) {
             bool ocarinaUiActive = false;
-            if (Oot3dNativeGame::ReadTopScreenOcarinaUiActive(
+            in.OcarinaUiActive =
+                Oot3dNativeGame::ReadTopScreenOcarinaUiActive(
                     process.Memory(), &ocarinaUiActive) &&
-                ocarinaUiActive) {
-              Oot3dNativeGame::TopScreenOcarinaRelocationStats stats;
-              if (Oot3dNativeGame::RelocateTopScreenOcarinaDraws(
-                      *in.CurrentVisualFrame,
-                      in.SelectedBottom->InputPhysicalAddress, &stats)) {
-                ++topScreenOcarinaRelocatedFrames;
-                topScreenOcarinaRelocatedDraws += stats.DrawsRelocated;
-              }
-            }
+                ocarinaUiActive;
           }
           Oot3dNativeGame::ComposeTopScreenFrontendFrame(
               *in.CurrentVisualFrame,
@@ -5597,6 +5708,22 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
               bool selectedNewVisualFrame = false;
               if (in.CurrentVisualFrame.has_value()) {
                 auto currentVisualFrame = std::move(in.CurrentVisualFrame);
+                if (in.OcarinaUiActive && in.SelectedBottom.has_value()) {
+                  Oot3dNativeGame::TopScreenOcarinaRelocationStats stats;
+                  const bool relocated =
+                      Oot3dNativeGame::RelocateTopScreenOcarinaDraws(
+                          *currentVisualFrame,
+                          in.SelectedBottom->InputPhysicalAddress, &stats);
+                  if (relocated) {
+                    ++topScreenOcarinaRelocatedFrames;
+                    topScreenOcarinaRelocatedDraws += stats.DrawsRelocated;
+                  }
+                  nativeControlPollingState.OcarinaBrowserVisible =
+                      relocated && stats.BrowserVisible;
+                  nativeControlPollingState.OcarinaCursorTile =
+                      relocated ? stats.CursorTile : -1;
+                }
+                nativeControlPollingState.OcarinaUiActive = in.OcarinaUiActive;
                 in.CurrentVisualFrame.reset();
                 {
                   selectedNewVisualFrame = true;
@@ -7815,6 +7942,10 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                     topScreenOcarinaRelocatedFrames},
                    {"topscreen_ocarina_relocated_draws",
                     topScreenOcarinaRelocatedDraws},
+                   {"topscreen_ocarina_taps_issued",
+                    nativeControlPollingState.OcarinaTapsIssued},
+                   {"topscreen_ocarina_steps_refused",
+                    nativeControlPollingState.OcarinaStepsRefused},
                    {"backend_profile",
                     uiLifecycleBridge.Runtime().Profile().id},
                    {"matched_entries", bridge.matched_entries},

--- a/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_a32_window.cpp
@@ -541,6 +541,18 @@ struct NativeFramePhaseTiming {
   double PresentSeconds = 0.0;
 };
 
+// Wall-clock spans that partition each thread's time. Main's spans plus its
+// waits sum to the host loop; the guest thread's spans are disjoint from them.
+struct NativeThreadSpanTiming {
+  double MainStartFrameSeconds = 0.0;
+  double MainPresentHalfSeconds = 0.0;
+  double MainHudAndEndFrameSeconds = 0.0;
+  double MainWaitForGuestSeconds = 0.0;
+  double GuestStepSeconds = 0.0;
+  double GuestDrainSeconds = 0.0;
+  double GuestHudBuildSeconds = 0.0;
+};
+
 struct NativeAudioOutputDiagnostics {
   void Observe(uint32_t hostFrame, int32_t before, int32_t after,
                uint64_t requestedFrames, int32_t desiredBuffered) {
@@ -3986,6 +3998,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
 #endif
 
   NativeFramePhaseTiming phaseTiming;
+  NativeThreadSpanTiming spanTiming;
   // Runs one unit of guest work per presentation on a persistent thread and
   // joins it before main touches guest state again. With the guest thread
   // disabled the same units execute inline, so both modes share one loop.
@@ -4806,6 +4819,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     widescreenProjection.CurrentHostFrame =
         static_cast<uint32_t>(presentationFrameCount);
     WindowDemoFrameTiming frameTiming;
+    const auto mainFrameStart = std::chrono::steady_clock::now();
     if (!PrepareNextWindowDemoFrame(hostArgs, window, timing, frameTiming)) {
       continue;
     }
@@ -4948,11 +4962,17 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     api.SetViewport(0, 0, static_cast<int>(width), static_cast<int>(height));
     api.SetScissor(0, 0, static_cast<int>(width), static_cast<int>(height));
     phaseTiming.FrameStartSeconds += SecondsSince(phaseStart);
+    spanTiming.MainStartFrameSeconds += SecondsSince(mainFrameStart);
     const uint32_t guestRefreshIterations =
         std::max<uint32_t>(1U, guestRefreshesDue);
     // Guest unit 1: input routing and one guest step. Runs on the guest
     // thread while main waits in StartFrame; touches no renderer state.
     const auto guestStep = [&](uint32_t guestRefreshIndex) -> bool {
+      const auto spanStart = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{spanStart, spanTiming.GuestStepSeconds};
       // Private to this unit: main uses its own phaseStart/error meanwhile.
       auto phaseStart = std::chrono::steady_clock::now();
       std::string error;
@@ -5695,6 +5715,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     // accumulator. Overlaps the present half; touches no renderer state
     // except through the scene-view mailbox.
     const auto guestDrain = [&]() {
+      const auto spanStart = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{spanStart, spanTiming.GuestDrainSeconds};
       // Private to this unit: main uses its own phaseStart/error meanwhile.
       auto phaseStart = std::chrono::steady_clock::now();
       std::string error;
@@ -6158,6 +6183,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
                oot3d::ui::kUiSubsystemCount>
         hudPrimitives;
     const auto buildHud = [&]() {
+      const auto t0 = std::chrono::steady_clock::now();
+      struct SpanEnd {
+        std::chrono::steady_clock::time_point Start; double &Total;
+        ~SpanEnd() { Total += SecondsSince(Start); }
+      } spanEnd{t0, spanTiming.GuestHudBuildSeconds};
       for (std::size_t subsystemIndex = 0;
            subsystemIndex < oot3d::ui::kUiSubsystemCount; ++subsystemIndex) {
         hudPrimitives[subsystemIndex].reset();
@@ -6220,7 +6250,11 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
         guestStep(guestRefreshesDue - 1U);
       }
     });
-    guestWorker.Wait();
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      guestWorker.Wait();
+      spanTiming.MainWaitForGuestSeconds += SecondsSince(t0);
+    }
     if (guestStopRequested) {
       hostLoopExitReason = "guest_requested_stop";
       window.Close();
@@ -6233,8 +6267,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
       }
       buildHud();
     });
-    presentHalf(presentInputs);
-    guestWorker.Wait();
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      presentHalf(presentInputs);
+      spanTiming.MainPresentHalfSeconds += SecondsSince(t0);
+    }
+    {
+      const auto t0 = std::chrono::steady_clock::now();
+      guestWorker.Wait();
+      spanTiming.MainWaitForGuestSeconds += SecondsSince(t0);
+    }
     flushSceneView();
     renderHud();
 
@@ -6250,6 +6292,7 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
     picaSemanticTrace.RecordFrameBoundary(
         presentationFrameCount, frameCount, guestRefreshesDue != 0U);
     phaseTiming.PresentSeconds += SecondsSince(phaseStart);
+    spanTiming.MainHudAndEndFrameSeconds += SecondsSince(phaseStart);
     ++presentationFrameCount;
     ++runFrameCount;
 #if defined(__SWITCH__)
@@ -8982,6 +9025,16 @@ void RunOot3dNativeA32Window(const Oot3dNativeGameLaunch &launch) {
             {"phase_timing",
              {{"guest_seconds", phaseTiming.GuestSeconds},
               {"frame_start_seconds", phaseTiming.FrameStartSeconds},
+              {"thread_spans",
+               {{"main_start_frame_seconds", spanTiming.MainStartFrameSeconds},
+                {"main_present_half_seconds", spanTiming.MainPresentHalfSeconds},
+                {"main_hud_and_end_frame_seconds",
+                 spanTiming.MainHudAndEndFrameSeconds},
+                {"main_wait_for_guest_seconds",
+                 spanTiming.MainWaitForGuestSeconds},
+                {"guest_step_seconds", spanTiming.GuestStepSeconds},
+                {"guest_drain_seconds", spanTiming.GuestDrainSeconds},
+                {"guest_hud_build_seconds", spanTiming.GuestHudBuildSeconds}}},
               {"dsp_mix_seconds", phaseTiming.DspMixSeconds},
               {"audio_output_seconds", phaseTiming.AudioOutputSeconds},
               {"pica_submit_seconds", phaseTiming.PicaSubmitSeconds},

--- a/tools/oot3d/native_game_runtime/oot3d_native_game_bootstrap.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_game_bootstrap.cpp
@@ -727,6 +727,8 @@ bool ParseOot3dNativeGameArgs(int argc, char** argv, Oot3dNativeGameLaunch& laun
                 ParseU32(argv[++index], "benchmark warm-up frame count");
         } else if (arg == "--throughput-benchmark") {
             launch.Host.ThroughputBenchmark = true;
+        } else if (arg == "--guest-thread") {
+            launch.Host.GuestThread = true;
         } else if (arg == "--max-seconds" && index + 1 < argc) {
             launch.Host.MaxSeconds = std::max(0.0, ParseDouble(argv[++index], "maximum seconds"));
         } else if (arg == "--fixed-delta-seconds" && index + 1 < argc) {

--- a/tools/oot3d/native_game_runtime/oot3d_native_ui_lifecycle_bridge_tests.cpp
+++ b/tools/oot3d/native_game_runtime/oot3d_native_ui_lifecycle_bridge_tests.cpp
@@ -267,12 +267,16 @@ int main() {
                                     kPauseTopPageResource) &&
           gameplayHudMemory.Write32(kPauseTopPageResource + 0x4CU, 0x14001234U),
       "cannot seed gameplay HUD fixture");
-  bool ocarinaUiActive = false;
+  // This ordinary gameplay HUD fixture seeds no ocarina performance fields
+  // (scene +0x2B80/+0x2B82 stay zero), so the predicate must read inactive.
+  // It previously "activated" only through the inverted `result != 0x00FF`
+  // branch treating the zero idle value as a song result.
+  bool ocarinaUiActive = true;
   Require(ReadTopScreenOcarinaUiActive(gameplayHudMemory, &ocarinaUiActive,
                                        &error) &&
-              ocarinaUiActive,
-          "gameplay HUD regression fixture did not activate the local Ocarina "
-          "predicate");
+              !ocarinaUiActive,
+          "ordinary gameplay HUD fixture must not report the Ocarina UI as "
+          "active");
   Oot3dNativeUiLifecycleBridge gameplayHudBridge(gameplayHudMemory);
   gameplayHudBridge.BeginHostFrame(1U);
   Require(gameplayHudBridge.ObserveGuestEntry(kGameplayHudDraw).matched,

--- a/tools/oot3d/native_game_runtime/oot3d_top_screen_frontend_composition.h
+++ b/tools/oot3d/native_game_runtime/oot3d_top_screen_frontend_composition.h
@@ -4,9 +4,13 @@
 #include "oot3d_top_screen_mod_profile.h"
 
 #include <algorithm>
+#include <array>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <vector>
 
 namespace Oot3dNativeGame {
-
 // The mod swaps the two native targets. The desktop frontend instead retains
 // the upper scene and draws the relocated menu over it, in native draw order.
 inline TopScreenPauseTargetPlan ResolveTopScreenFrontendTargetCommand(
@@ -77,62 +81,96 @@ struct TopScreenOcarinaRelocationStats {
     size_t DrawsRelocated = 0;
     size_t OpaqueDrawsSkipped = 0;
     size_t UntexturedDrawsSkipped = 0;
+    bool BrowserVisible = false;
+    int CursorTile = -1; // selected song tile while the browser is visible
 };
 
-// The ocarina performance UI (staff, notes, song banner) is drawn only to the
-// lower screen, which the single-screen layout never shows. While a
-// performance is active, re-emit the lower target's alpha-blended, textured
-// draws over the upper scene and defer the upper scanout past them. The lower
-// canvas is 320 lines tall against the upper 400, so its viewport is shifted
-// by 40 to center it, the same placement ResolveTopScreenFrontendTargetCommand
-// gives the relocated frontend. The lower background fills opaquely
-// (One/Zero) and is left behind; copying it would paint over the scene.
+// The ocarina performance UI is drawn only to the lower screen, which the
+// single-screen layout never shows. While a performance is active, re-emit
+// its overlay quads over the upper scene the way the TopScreen mod lays them
+// out: the note staff along the bottom edge and the song-name banner along
+// the top edge, nothing else.
+//
+// Everything is authored on the 320x240 lower canvas through a fixed ortho
+// projection in the vertex-shader constants: clip.x = c0.w - y/120 and
+// clip.y = 1 - x/160. A band of quads is moved vertically by re-emitting the
+// draw with a filtered index buffer and a different c0.w; the vertex streams
+// stay shared with the source draw, which matters because those buffers are
+// refreshed in place until the draw executes. The copy takes the upper
+// target's full viewport, shifted 40 columns to center the 320-column canvas
+// in 400.
+//
+// The 512x256 ocarina-page batch has fixed quad slots: 0-2 the browser's
+// staff strip, 35-37 its song-name banner, 39-44 the note glyphs on the
+// staff, 51-54 the free-play page's message/notes bar. The remaining slots
+// (song grid, cursor, note buttons, ocarina art, BACK and list icons) stay
+// hidden; the opaque backdrop (One/Zero blend) and other page art are not
+// copied. Song-name and message text arrive in separate glyph draws and
+// follow their band. Canvas-top content (y < 120) moves to the screen bottom
+// and canvas-bottom content to the screen top.
 inline bool RelocateTopScreenOcarinaDraws(
     Oot3dPicaVisualFrame& frame, uint32_t lowerColorAddress,
     TopScreenOcarinaRelocationStats* stats = nullptr) {
     constexpr int16_t kLowerCanvasCenteringOffset = 40;
+    constexpr float kCanvasHalfHeight = 120.0F;
+    constexpr float kStaffShift = 168.0F;   // y 4..68 -> 172..236
+    constexpr float kBannerShift = -196.0F; // y 200..240 -> 4..44
+    constexpr uint32_t kOcarinaPageWidth = 512;
+    constexpr uint32_t kOcarinaPageHeight = 256;
+    constexpr size_t kOcarinaPageQuads = 108;
+    constexpr size_t kBannerQuad = 35;
+    constexpr size_t kCursorQuad = 18;
+    constexpr uint32_t kGlyphAtlasSize = 256;
+    constexpr float kGlyphMaxSize = 32.0F;
+    constexpr std::array<size_t, 13> kStaffQuads{0,  1,  2,  39, 40, 41, 42,
+                                                 43, 44, 51, 52, 53, 54};
+    constexpr std::array<size_t, 3> kBannerQuads{35, 36, 37};
     const uint32_t upperColorAddress = frame.TopTransfer.InputPhysicalAddress;
     if (lowerColorAddress == 0U || upperColorAddress == 0U ||
         lowerColorAddress == upperColorAddress) {
         return false;
     }
     std::optional<Oot3dPicaFramebufferState> upperTarget;
+    std::optional<Oot3dPicaViewportState> upperViewport;
     uint64_t lastSubmission = 0;
     for (const auto& draw : frame.Draws) {
         lastSubmission = std::max(lastSubmission, draw.SubmissionId);
         if (!upperTarget.has_value() &&
             draw.State.Framebuffer.ColorPhysicalAddress == upperColorAddress) {
             upperTarget = draw.State.Framebuffer;
+            upperViewport = draw.State.Viewport;
         }
     }
     if (!upperTarget.has_value()) {
         return false;
     }
     TopScreenOcarinaRelocationStats result;
-    const size_t originalCount = frame.Draws.size();
-    for (size_t index = 0; index < originalCount; ++index) {
-        const auto& draw = frame.Draws[index];
-        if (draw.State.Framebuffer.ColorPhysicalAddress != lowerColorAddress) {
-            continue;
-        }
-        const auto& blend = draw.State.OutputMerger.Blend;
-        if (!blend.Enabled ||
-            blend.DestinationColor == Oot3dPicaBlendFactor::Zero) {
-            ++result.OpaqueDrawsSkipped;
-            continue;
-        }
-        const bool textured = std::any_of(
-            draw.Textures.begin(), draw.Textures.end(),
-            [](const Oot3dPicaVulkanTextureBinding& texture) {
-                return texture.State.Enabled;
-            });
-        if (!textured) {
-            ++result.UntexturedDrawsSkipped;
-            continue;
-        }
+    const auto emit = [&](const Oot3dPicaVulkanDrawPlan& draw,
+                          std::span<const size_t> quads, float shift,
+                          uint64_t salt) {
+        const auto indices = draw.ResolvedIndexBytes();
         Oot3dPicaVulkanDrawPlan copy = draw;
+        if (!quads.empty()) {
+            copy.IndexBytes.clear();
+            copy.IndexBytes.reserve(quads.size() * 12U);
+            for (const size_t quad : quads) {
+                copy.IndexBytes.insert(copy.IndexBytes.end(),
+                                       indices.begin() + quad * 12U,
+                                       indices.begin() + quad * 12U + 12U);
+            }
+            copy.SharedIndexBytes.reset();
+            copy.VertexCount = static_cast<uint32_t>(copy.IndexBytes.size() / 2U);
+        }
+        copy.VertexShader.Uniforms.Floats[0][3] -= shift / kCanvasHalfHeight;
+        // A distinct identity keeps the relocated copy out of the source
+        // draw's geometry cache entry while still tracking its content.
+        copy.GeometryIdentity = draw.GeometryIdentity ^ salt;
         copy.SubmissionId = ++lastSubmission;
         copy.State.Framebuffer = *upperTarget;
+        if (upperViewport.has_value()) {
+            copy.State.Viewport.HalfWidth = upperViewport->HalfWidth;
+            copy.State.Viewport.CornerX = upperViewport->CornerX;
+        }
         copy.State.Viewport.CornerY = static_cast<int16_t>(
             copy.State.Viewport.CornerY + kLowerCanvasCenteringOffset);
         // An overlay must not be occluded by the scene's depth buffer.
@@ -144,6 +182,96 @@ inline bool RelocateTopScreenOcarinaDraws(
         }
         frame.Draws.push_back(std::move(copy));
         ++result.DrawsRelocated;
+    };
+    const size_t originalCount = frame.Draws.size();
+    for (size_t index = 0; index < originalCount; ++index) {
+        // Copies are appended, which may reallocate; re-resolve each pass.
+        const Oot3dPicaVulkanDrawPlan draw = frame.Draws[index];
+        if (draw.State.Framebuffer.ColorPhysicalAddress != lowerColorAddress) {
+            continue;
+        }
+        const auto& blend = draw.State.OutputMerger.Blend;
+        const bool opaqueFill =
+            !blend.Enabled ||
+            blend.DestinationColor == Oot3dPicaBlendFactor::Zero;
+        const bool textured = std::any_of(
+            draw.Textures.begin(), draw.Textures.end(),
+            [](const Oot3dPicaVulkanTextureBinding& texture) {
+                return texture.State.Enabled;
+            });
+        if (!textured || !draw.Indexed || !draw.IndicesAre16Bit ||
+            draw.VertexBindings.empty() ||
+            draw.VertexBindings[0].ByteStride < 8U) {
+            ++result.UntexturedDrawsSkipped;
+            continue;
+        }
+        const auto indices = draw.ResolvedIndexBytes();
+        const auto positions = draw.VertexBindings[0].ResolvedBytes();
+        const size_t stride = draw.VertexBindings[0].ByteStride;
+        const bool ocarinaPage =
+            draw.Textures[0].State.Width == kOcarinaPageWidth &&
+            draw.Textures[0].State.Height == kOcarinaPageHeight &&
+            indices.size() == kOcarinaPageQuads * 12U;
+        if (ocarinaPage) {
+            const auto quadOrigin = [&](size_t quad, float* x, float* y) {
+                const uint16_t vertex = static_cast<uint16_t>(
+                    indices[quad * 12U] | (indices[quad * 12U + 1U] << 8));
+                float xy[2];
+                std::memcpy(xy, positions.data() + vertex * stride, sizeof(xy));
+                *x = xy[0];
+                *y = xy[1];
+            };
+            float bannerX = 0.0F;
+            float bannerY = 0.0F;
+            quadOrigin(kBannerQuad, &bannerX, &bannerY);
+            result.BrowserVisible = result.BrowserVisible || bannerX < 320.0F;
+            // The cursor quad sits on the selected song tile: four columns by
+            // three rows of 72x44 cells from (20,72).
+            float cursorX = 0.0F;
+            float cursorY = 0.0F;
+            quadOrigin(kCursorQuad, &cursorX, &cursorY);
+            if (result.BrowserVisible && cursorX >= 0.0F && cursorX < 320.0F) {
+                const int column = static_cast<int>((cursorX - 20.0F + 36.0F) / 72.0F);
+                const int row = static_cast<int>((cursorY - 72.0F + 22.0F) / 44.0F);
+                if (column >= 0 && column < 4 && row >= 0 && row < 3) {
+                    result.CursorTile = row * 4 + column;
+                }
+            }
+            emit(draw, kStaffQuads, kStaffShift, 0x4F43415249'4E4131ULL);
+            emit(draw, kBannerQuads, kBannerShift, 0x4F43415249'4E4132ULL);
+            continue;
+        }
+        // Song-name and message text: small glyph quads from the font atlas.
+        // Anything larger is page art (backdrop, grid trim).
+        bool glyphs = draw.Textures[0].State.Width == kGlyphAtlasSize &&
+                      draw.Textures[0].State.Height == kGlyphAtlasSize;
+        float textMinY = 1e9F;
+        for (size_t quad = 0; glyphs && quad * 12U + 12U <= indices.size(); ++quad) {
+            float minX = 1e9F, maxX = -1e9F, minY = 1e9F, maxY = -1e9F;
+            for (size_t k = 0; k < 6U; ++k) {
+                const uint16_t vertex = static_cast<uint16_t>(
+                    indices[quad * 12U + k * 2U] |
+                    (indices[quad * 12U + k * 2U + 1U] << 8));
+                float xy[2];
+                std::memcpy(xy, positions.data() + vertex * stride, sizeof(xy));
+                minX = std::min(minX, xy[0]);
+                maxX = std::max(maxX, xy[0]);
+                minY = std::min(minY, xy[1]);
+                maxY = std::max(maxY, xy[1]);
+            }
+            glyphs = maxX - minX <= kGlyphMaxSize && maxY - minY <= kGlyphMaxSize;
+            textMinY = std::min(textMinY, minY);
+        }
+        if (!glyphs) {
+            if (opaqueFill) {
+                ++result.OpaqueDrawsSkipped;
+            } else {
+                ++result.UntexturedDrawsSkipped;
+            }
+            continue;
+        }
+        emit(draw, {}, textMinY < kCanvasHalfHeight ? kStaffShift : kBannerShift,
+             0x4F43415249'4E4133ULL);
     }
     if (stats != nullptr) {
         *stats = result;

--- a/tools/oot3d/native_game_runtime/oot3d_top_screen_frontend_composition.h
+++ b/tools/oot3d/native_game_runtime/oot3d_top_screen_frontend_composition.h
@@ -73,4 +73,85 @@ inline bool ComposeTopScreenFrontendFrame(Oot3dPicaVisualFrame& frame,
     return true;
 }
 
+struct TopScreenOcarinaRelocationStats {
+    size_t DrawsRelocated = 0;
+    size_t OpaqueDrawsSkipped = 0;
+    size_t UntexturedDrawsSkipped = 0;
+};
+
+// The ocarina performance UI (staff, notes, song banner) is drawn only to the
+// lower screen, which the single-screen layout never shows. While a
+// performance is active, re-emit the lower target's alpha-blended, textured
+// draws over the upper scene and defer the upper scanout past them. The lower
+// canvas is 320 lines tall against the upper 400, so its viewport is shifted
+// by 40 to center it, the same placement ResolveTopScreenFrontendTargetCommand
+// gives the relocated frontend. The lower background fills opaquely
+// (One/Zero) and is left behind; copying it would paint over the scene.
+inline bool RelocateTopScreenOcarinaDraws(
+    Oot3dPicaVisualFrame& frame, uint32_t lowerColorAddress,
+    TopScreenOcarinaRelocationStats* stats = nullptr) {
+    constexpr int16_t kLowerCanvasCenteringOffset = 40;
+    const uint32_t upperColorAddress = frame.TopTransfer.InputPhysicalAddress;
+    if (lowerColorAddress == 0U || upperColorAddress == 0U ||
+        lowerColorAddress == upperColorAddress) {
+        return false;
+    }
+    std::optional<Oot3dPicaFramebufferState> upperTarget;
+    uint64_t lastSubmission = 0;
+    for (const auto& draw : frame.Draws) {
+        lastSubmission = std::max(lastSubmission, draw.SubmissionId);
+        if (!upperTarget.has_value() &&
+            draw.State.Framebuffer.ColorPhysicalAddress == upperColorAddress) {
+            upperTarget = draw.State.Framebuffer;
+        }
+    }
+    if (!upperTarget.has_value()) {
+        return false;
+    }
+    TopScreenOcarinaRelocationStats result;
+    const size_t originalCount = frame.Draws.size();
+    for (size_t index = 0; index < originalCount; ++index) {
+        const auto& draw = frame.Draws[index];
+        if (draw.State.Framebuffer.ColorPhysicalAddress != lowerColorAddress) {
+            continue;
+        }
+        const auto& blend = draw.State.OutputMerger.Blend;
+        if (!blend.Enabled ||
+            blend.DestinationColor == Oot3dPicaBlendFactor::Zero) {
+            ++result.OpaqueDrawsSkipped;
+            continue;
+        }
+        const bool textured = std::any_of(
+            draw.Textures.begin(), draw.Textures.end(),
+            [](const Oot3dPicaVulkanTextureBinding& texture) {
+                return texture.State.Enabled;
+            });
+        if (!textured) {
+            ++result.UntexturedDrawsSkipped;
+            continue;
+        }
+        Oot3dPicaVulkanDrawPlan copy = draw;
+        copy.SubmissionId = ++lastSubmission;
+        copy.State.Framebuffer = *upperTarget;
+        copy.State.Viewport.CornerY = static_cast<int16_t>(
+            copy.State.Viewport.CornerY + kLowerCanvasCenteringOffset);
+        // An overlay must not be occluded by the scene's depth buffer.
+        copy.State.OutputMerger.Depth.TestEnabled = false;
+        copy.State.OutputMerger.Depth.WriteEnabled = false;
+        if (frame.StrictDrawIdentities.size() == frame.Draws.size()) {
+            frame.StrictDrawIdentities.push_back(
+                ComputeOot3dPicaVisualDrawIdentity(copy));
+        }
+        frame.Draws.push_back(std::move(copy));
+        ++result.DrawsRelocated;
+    }
+    if (stats != nullptr) {
+        *stats = result;
+    }
+    if (result.DrawsRelocated == 0U) {
+        return false;
+    }
+    return ComposeTopScreenFrontendFrame(frame, true);
+}
+
 } // namespace Oot3dNativeGame

--- a/tools/oot3d/ui_topscreen/oot3d_top_screen_mod_profile.cpp
+++ b/tools/oot3d/ui_topscreen/oot3d_top_screen_mod_profile.cpp
@@ -2609,7 +2609,12 @@ bool ReadTopScreenOcarinaUiActive(NativeA32Memory &memory, bool *active,
       *error = "cannot read TopScreen Ocarina UI state";
     return false;
   }
-  if (ocarinaResult != 0x00FFU) {
+  // Result branch (inherited, provisional): treat a nonzero, non-0xFF result
+  // as active. Verified in-game only for the two endpoints: idle reads 0x0000
+  // and a performance in progress reads 0x00FF; excluding 0x0000 stops the
+  // earlier bare `!= 0x00FF` from reporting active during ordinary HUD play.
+  // The nonzero-result (completed-song) case is not yet sampled.
+  if (ocarinaResult != 0x00FFU && ocarinaResult != 0x0000U) {
     *active = true;
     return true;
   }
@@ -2633,7 +2638,9 @@ bool ReadTopScreenOcarinaUiActive(NativeA32Memory &memory, bool *active,
       *error = "cannot read TopScreen Ocarina action";
     return false;
   }
-  *active = ocarinaAction > 1U;
+  // A performance in progress reads action 1 (verified in-game); idle reads 0.
+  // The earlier `> 1U` missed the active state entirely.
+  *active = ocarinaAction != 0U;
   return true;
 }
 

--- a/tools/oot3d/ui_topscreen/oot3d_top_screen_mod_profile_tests.cpp
+++ b/tools/oot3d/ui_topscreen/oot3d_top_screen_mod_profile_tests.cpp
@@ -2026,12 +2026,23 @@ int main() {
   Require(
       questModelMemory.Write32(0x005043E0U, questDrawScene) &&
           questModelMemory.Write32(questDrawScene + 0x20ACU, 0U) &&
-          questModelMemory.Write16(questDrawScene + 0x2B82U, 0x00FFU) &&
-          questModelMemory.Write16(questDrawScene + 0x2B80U, 1U) &&
+          questModelMemory.Write16(questDrawScene + 0x2B82U, 0x0000U) &&
+          questModelMemory.Write16(questDrawScene + 0x2B80U, 0U) &&
           ReadTopScreenOcarinaUiActive(questModelMemory, &ocarinaUiActive,
                                       &error) &&
           !ocarinaUiActive,
-      "TopScreen 1.2 Ocarina gate blocked the native idle state");
+      "TopScreen 1.2 Ocarina gate reported active during ordinary HUD "
+      "gameplay");
+  // Verified in-game (Kokiri Forest, D-pad Down): a performance in progress
+  // reads action 0x0001 and result 0x00FF while the native HUD is suppressed.
+  // The earlier gate mislabelled this exact state as idle.
+  Require(
+      questModelMemory.Write16(questDrawScene + 0x2B82U, 0x00FFU) &&
+          questModelMemory.Write16(questDrawScene + 0x2B80U, 1U) &&
+          ReadTopScreenOcarinaUiActive(questModelMemory, &ocarinaUiActive,
+                                      &error) &&
+          ocarinaUiActive,
+      "TopScreen 1.2 Ocarina gate missed a performance in progress");
   Require(
       questModelMemory.Write16(questDrawScene + 0x2B80U, 2U) &&
           ReadTopScreenOcarinaUiActive(questModelMemory, &ocarinaUiActive,


### PR DESCRIPTION
## Problem
In the TopScreen (single-screen) profile the ocarina performance UI never appeared: the staff, notes and song banner are drawn only to the lower screen, which the layout never presents. Pulling out the ocarina (D-pad Down) showed Link playing with no UI.

## Change
Two commits on top of `port/linux-nri`:

1. **Detection fix** — `ReadTopScreenOcarinaUiActive` was inverted: idle (result `0x0000`) read as active and a performance in progress (result `0x00FF`, action `1`) read as idle. Both endpoints were sampled in-game against screenshots; the two tests that pinned the inverted contract are corrected, and the unsampled completed-song result branch is kept but marked provisional. Also reports the Quest-hook counters.

2. **Presenter + browsing** — while a performance is active, re-emit the lower target's ocarina-page draws over the upper scene the way the mod lays them out: note staff along the bottom edge, song-name banner along the top, nothing else (backdrop, note buttons, song grid and corner icons hidden). Quads are moved through the vertex-shader projection constant (`clip.x = c0.w - y/120`), not by editing vertex bytes — the shared vertex buffers are refreshed in place until the draw executes, so a byte snapshot renders stale geometry. Relocation runs at present time (after the drain); the guest-memory predicate is read while the guest is idle. With the grid hidden, D-pad Left/Right browse songs by tapping the tile the game takes a touch on (opening the list from the free-play page first); the presenter publishes the game's cursor tile and unlearned songs — which the game refuses and which clear the staff — are skipped, returning to the origin when nothing else is learned. Consumed D-pad bits are cleared so the item-slot D-pad actions do not fire.

The mechanism is the same host-presenter shape the single-screen HUD already uses; it does not need the mod's guest-side IPS relocation, which is unreachable in the whole-AOT product build.

## Verification
Headless on a Kokiri Forest snapshot, plus a live session (7 ocarina pulls, 2433 relocated frames, song cycling exercised — 81 taps, 66 refused skips):
- Free-play: "Play the ocarina." bar at the bottom where played notes show, nothing else.
- Browser: "Zelda's Lullaby" in the top banner, `X A Y X A Y` on the bottom staff.
- D-pad Right sweep with one learned song: 13 taps (open + 12), 11 refused, ends back on the learned song with the staff restored.
- Normal gameplay: relocates nothing, HUD unchanged.

Note for reviewers: input-timeline frames are guest frames while `--screenshot-start-frame` counts host frames, which run at half rate in these replays.

Branched from `port/linux-nri`; independent of the other open PRs. The mod's edge navigation arrows (its own art) are not reproduced — the D-pad does that job.